### PR TITLE
Fixed Typo in Big O Complexity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Below is the list of some of the most used Big O notations and their performance
 | **O(1)**       | 1                            | 1                             | 1                               |
 | **O(log N)**   | 3                            | 6                             | 9                               |
 | **O(N)**       | 10                           | 100                           | 1000                            |
-| **O(N log N)** | 30                           | 60                            | 9000                            |
+| **O(N log N)** | 30                           | 600                           | 9000                            |
 | **O(N^2)**     | 100                          | 10000                         | 1000000                         |
 | **O(2^N)**     | 1024                         | 1.26e+29                      | 1.07e+301                       |
 | **O(N!)**      | 3628800                      | 9.3e+157                      | 4.02e+2567                      |


### PR DESCRIPTION
Just a typo fix in the README.  