### PR TITLE
Fix LinkedList

### DIFF
--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -60,7 +60,7 @@ export default class LinkedList {
     let deletedNode = null;
 
     // If the head must be deleted then make 2nd node to be a head.
-    if (this.compare.equal(this.head.value, value)) {
+    while (this.head && this.compare.equal(this.head.value, value)) {
       deletedNode = this.head;
       this.head = this.head.next;
     }

--- a/src/data-structures/linked-list/__test__/LinkedList.test.js
+++ b/src/data-structures/linked-list/__test__/LinkedList.test.js
@@ -33,6 +33,7 @@ describe('LinkedList', () => {
     expect(linkedList.delete(5)).toBeNull();
 
     linkedList.append(1);
+    linkedList.append(1);
     linkedList.append(2);
     linkedList.append(3);
     linkedList.append(3);
@@ -45,10 +46,10 @@ describe('LinkedList', () => {
 
     const deletedNode = linkedList.delete(3);
     expect(deletedNode.value).toBe(3);
-    expect(linkedList.toString()).toBe('1,2,4,5');
+    expect(linkedList.toString()).toBe('1,1,2,4,5');
 
     linkedList.delete(3);
-    expect(linkedList.toString()).toBe('1,2,4,5');
+    expect(linkedList.toString()).toBe('1,1,2,4,5');
 
     linkedList.delete(1);
     expect(linkedList.toString()).toBe('2,4,5');


### PR DESCRIPTION
This is a small fix for LinkedList `delete` method. I have updated LinkedList.test.js to reproduce the issue. This test fails for the previous version of the method.