### PR TITLE
Fix bug in 'BinarySearchTreeNode.js

### DIFF
--- a/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
+++ b/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
@@ -120,7 +120,7 @@ export default class BinarySearchTreeNode extends BinaryTreeNode {
       }
     }
 
-    return nodeToRemove;
+    return parent;
   }
 
   /**


### PR DESCRIPTION
I think that properties of the returned object correspond to the tree state before the node is deleted.

``` 110.         nodeToRemove.value = nodeToRemove.right.value;```

You have changed the value of ``` nodeToRemove```  with the value that has to be replaced.Now when you return ``` nodeToRemove.value```  it would return the node that is being replaced to that position, not the node that is being deleted. Instead return ``` parent``` 