### PR TITLE
chore: ignore .DS_Store in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 coverage
 .vscode
+.DS_Store


### PR DESCRIPTION
Just update .gitignore to ignore .DS_Store on macOS.