### PR TITLE
Fix knuthMorrisPratt for empty word request

### DIFF
--- a/src/algorithms/string/knuth-morris-pratt/__test__/knuthMorrisPratt.test.js
+++ b/src/algorithms/string/knuth-morris-pratt/__test__/knuthMorrisPratt.test.js
@@ -2,6 +2,9 @@ import knuthMorrisPratt from '../knuthMorrisPratt';
 
 describe('knuthMorrisPratt', () => {
   it('should find word position in given text', () => {
+    expect(knuthMorrisPratt('', '')).toBe(0);
+    expect(knuthMorrisPratt('a', '')).toBe(0);
+    expect(knuthMorrisPratt('a', 'a')).toBe(0);
     expect(knuthMorrisPratt('abcbcglx', 'abca')).toBe(-1);
     expect(knuthMorrisPratt('abcbcglx', 'bcgl')).toBe(3);
     expect(knuthMorrisPratt('abcxabcdabxabcdabcdabcy', 'abcdabcy')).toBe(15);

--- a/src/algorithms/string/knuth-morris-pratt/knuthMorrisPratt.js
+++ b/src/algorithms/string/knuth-morris-pratt/knuthMorrisPratt.js
@@ -30,6 +30,10 @@ function buildPatternTable(word) {
  * @return {number}
  */
 export default function knuthMorrisPratt(text, word) {
+  if (word.length === 0) {
+    return 0;
+  }
+
   let textIndex = 0;
   let wordIndex = 0;
 


### PR DESCRIPTION
While running property based tests - *based on fast-check* - on the implementation of knuthMorrisPratt I discovered what seems to be an inconsistency:

```javascript
knuthMorrisPratt("", "") === -1
knuthMorrisPratt("a", "a") === 0
```

The tests that discovered the issue are available in the commit: https://github.com/dubzzz/javascript-algorithms/commit/87329dd9b0215683018a346694cc2bf387fe32b4
If you are interested in this test method, I can issue another pull request for those property based tests.