### PR TITLE
choose pivot from median of three elements for quicksort

### DIFF
--- a/src/algorithms/sorting/quick-sort/QuickSort.js
+++ b/src/algorithms/sorting/quick-sort/QuickSort.js
@@ -14,13 +14,21 @@ export default class QuickSort extends Sort {
       return array;
     }
 
-    // Init left and right arrays.
+    // Init left, center, and right arrays.
     const leftArray = [];
     const rightArray = [];
+    const centerArray = [];
 
-    // Take the first element of array as a pivot.
-    const pivotElement = array.shift();
-    const centerArray = [pivotElement];
+    // Take the median element of first, mid, and last elements.
+    let pivotElement = array[0];
+    const mid = Math.floor(array.length / 2);
+    if ((array[mid] < array[array.length - 1] && array[mid] > array[0])
+        || (array[mid] > array[array.length - 1] && array[mid] < array[0])) {
+      pivotElement = array[mid];
+    } else if ((array[array.length - 1] < array[mid] && array[array.length - 1] > array[0])
+        || (array[array.length - 1] > array[mid] && array[array.length - 1] < array[0])) {
+      pivotElement = array[array.length - 1];
+    }
 
     // Split all array elements between left, center and right arrays.
     while (array.length) {

--- a/src/algorithms/sorting/quick-sort/__test__/QuickSort.test.js
+++ b/src/algorithms/sorting/quick-sort/__test__/QuickSort.test.js
@@ -8,10 +8,10 @@ import {
 } from '../../SortTester';
 
 // Complexity constants.
-const SORTED_ARRAY_VISITING_COUNT = 190;
-const NOT_SORTED_ARRAY_VISITING_COUNT = 62;
-const REVERSE_SORTED_ARRAY_VISITING_COUNT = 190;
-const EQUAL_ARRAY_VISITING_COUNT = 19;
+const SORTED_ARRAY_VISITING_COUNT = 66;
+const NOT_SORTED_ARRAY_VISITING_COUNT = 83;
+const REVERSE_SORTED_ARRAY_VISITING_COUNT = 66;
+const EQUAL_ARRAY_VISITING_COUNT = 20;
 
 describe('QuickSort', () => {
   it('should sort array', () => {


### PR DESCRIPTION
The method for choosing the pivot as implemented at the moment results in degenerate behaviour when the array is already sorted or reverse sorted. A better way is to choose the median of three elements (first, mid, last) as the pivot. See Robert Sedgewick. Implementing Quicksort Programs. Commun. ACM, 1(10):847–857, October 1978.