### PR TITLE
Fix Heap.remove() bug

### DIFF
--- a/src/data-structures/heap/Heap.js
+++ b/src/data-structures/heap/Heap.js
@@ -165,22 +165,17 @@ export default class Heap {
         // Move last element in heap to the vacant (removed) position.
         this.heapContainer[indexToRemove] = this.heapContainer.pop();
 
-        // Get parent.
         const parentItem = this.hasParent(indexToRemove) ? this.parent(indexToRemove) : null;
-        const leftChild = this.hasLeftChild(indexToRemove) ? this.leftChild(indexToRemove) : null;
 
-        // If there is no parent or parent is in incorrect order with the node
-        // we're going to delete then heapify down. Otherwise heapify up.
+        // If parent exists & heap property is violated, heapifyDown from parentIndex
+        // otherwise heapifyDown from deleted element index
         if (
-          leftChild !== null
-          && (
-            parentItem === null
-            || !this.pairIsInCorrectOrder(parentItem, this.heapContainer[indexToRemove])
-          )
+          parentItem !== null
+          && !this.pairIsInCorrectOrder(parentItem, this.heapContainer[indexToRemove])
         ) {
-          this.heapifyDown(indexToRemove);
+          this.heapifyDown(this.getParentIndex(indexToRemove));
         } else {
-          this.heapifyUp(indexToRemove);
+          this.heapifyDown(indexToRemove);
         }
       }
     }

--- a/src/data-structures/heap/__test__/MinHeap.test.js
+++ b/src/data-structures/heap/__test__/MinHeap.test.js
@@ -121,6 +121,25 @@ describe('MinHeap', () => {
     expect(minHeap.remove(3).peek()).toEqual(10);
     expect(minHeap.remove(11).toString()).toEqual('10,12');
     expect(minHeap.remove(3).peek()).toEqual(10);
+
+
+    const minHeap2 = new MinHeap();
+
+    minHeap2.add(5);
+    minHeap2.add(3);
+    minHeap2.add(2);
+
+    expect(minHeap2.toString()).toBe('2,5,3');
+    minHeap2.remove(3);
+    expect(minHeap2.toString()).toBe('2,5');
+
+    minHeap2.add(4);
+    minHeap2.add(1);
+    minHeap2.add(6);
+    expect(minHeap2.toString()).toBe('1,2,4,5,6');
+
+    minHeap2.remove(2);
+    expect(minHeap2.toString()).toBe('1,5,4,6');
   });
 
   it('should be possible to remove items from heap with heapify up', () => {


### PR DESCRIPTION
Way to replicate a bug in tests:

const minHeap = new MinHeap();

minHeap.add(5);
minHeap.add(3);
minHeap.add(2);

expect(minHeap.toString()).toBe('2,5,3');
minHeap.remove(3);
expect(minHeap.toString()).toBe('2,5');

minHeap.add(4);
minHeap.add(1);
minHeap.add(6);
expect(minHeap.toString()).toBe('1,2,4,5,6');

minHeap.remove(2);
expect(minHeap.toString()).toBe('1,5,4,6');
