### PR TITLE
Fix TrieNode.addChild so substrings get marked as complete words

### DIFF
--- a/src/data-structures/trie/TrieNode.js
+++ b/src/data-structures/trie/TrieNode.js
@@ -29,7 +29,10 @@ export default class TrieNode {
       this.children.set(character, new TrieNode(character, isCompleteWord));
     }
 
-    return this.children.get(character);
+    const childNode = this.children.get(character);
+    childNode.isCompleteWord = childNode.isCompleteWord || isCompleteWord;
+
+    return childNode;
   }
 
   /**

--- a/src/data-structures/trie/__test__/Trie.test.js
+++ b/src/data-structures/trie/__test__/Trie.test.js
@@ -41,11 +41,14 @@ describe('Trie', () => {
 
     trie.addWord('cat');
     trie.addWord('cats');
+    trie.addWord('carpet');
     trie.addWord('car');
     trie.addWord('caption');
 
     expect(trie.doesWordExist('cat')).toBe(true);
     expect(trie.doesWordExist('cats')).toBe(true);
+    expect(trie.doesWordExist('carpet')).toBe(true);
+    expect(trie.doesWordExist('car')).toBe(true);
     expect(trie.doesWordExist('cap')).toBe(false);
     expect(trie.doesWordExist('call')).toBe(false);
   });


### PR DESCRIPTION
## Fix for Trie.addWord (actual code changed is in TrieNode.addChild)

Currently when adding a substring of an existing word, the new word does not get marked as a complete word. Here's an example:

```js
const trie = new Trie();
trie.addWord('javascript');
trie.addWord('java');

trie.doesWordExist('java'); // returns false
```

This PR fixes the issue.