### PR TITLE
Feature: Add Trie.deleteWord and TrieNode.removeChild

### DIFF
--- a/src/data-structures/trie/Trie.js
+++ b/src/data-structures/trie/Trie.js
@@ -26,6 +26,35 @@ export default class Trie {
 
   /**
    * @param {string} word
+   * @return {Trie}
+   */
+  deleteWord(word) {
+    function depthFirstDelete(currentNode, charIndex) {
+      if (charIndex >= word.length) return;
+
+      const character = word[charIndex];
+      const nextNode = currentNode.getChild(character);
+
+      if (nextNode == null) return;
+
+      depthFirstDelete(nextNode, charIndex + 1);
+
+      if (charIndex === word.length - 1) {
+        nextNode.isCompleteWord = false;
+      }
+
+      // childNode is deleted only if:
+      // - childNode has NO children
+      // - childNode.isCompleteWord === false
+      currentNode.removeChild(character);
+    }
+
+    depthFirstDelete(this.head, 0);
+    return this;
+  }
+
+  /**
+   * @param {string} word
    * @return {string[]}
    */
   suggestNextCharacters(word) {

--- a/src/data-structures/trie/TrieNode.js
+++ b/src/data-structures/trie/TrieNode.js
@@ -39,6 +39,31 @@ export default class TrieNode {
 
   /**
    * @param {string} character
+   * @return {TrieNode}
+   */
+  removeChild(character) {
+    function isSafeToDelete(node) {
+      return (
+        node
+        && !node.isCompleteWord
+        && node.children.getKeys().length === 0
+      );
+    }
+
+    const childNode = this.getChild(character);
+
+    // delete childNode only if:
+    // - childNode has NO children
+    // - childNode.isCompleteWord === false
+    if (isSafeToDelete(childNode)) {
+      this.children.delete(character);
+    }
+
+    return this;
+  }
+
+  /**
+   * @param {string} character
    * @return {boolean}
    */
   hasChild(character) {

--- a/src/data-structures/trie/__test__/Trie.test.js
+++ b/src/data-structures/trie/__test__/Trie.test.js
@@ -23,6 +23,18 @@ describe('Trie', () => {
     expect(trie.head.getChild('c').getChild('a').getChild('t').toString()).toBe('t*');
   });
 
+  it('should delete words from trie', () => {
+    const trie = new Trie();
+
+    trie.addWord('carpet');
+    trie.addWord('car');
+    expect(trie.doesWordExist('carpet')).toBe(true);
+
+    trie.deleteWord('carpet');
+    expect(trie.doesWordExist('carpet')).toEqual(false);
+    expect(trie.doesWordExist('car')).toEqual(true);
+  });
+
   it('should suggests next characters', () => {
     const trie = new Trie();
 

--- a/src/data-structures/trie/__test__/TrieNode.test.js
+++ b/src/data-structures/trie/__test__/TrieNode.test.js
@@ -18,6 +18,36 @@ describe('TrieNode', () => {
     expect(trieNode.toString()).toBe('c:a,o');
   });
 
+  describe('removing child nodes', () => {
+    it('should delete child node if the child node has NO children', () => {
+      const trieNode = new TrieNode('c');
+      trieNode.addChild('a');
+      expect(trieNode.hasChild('a')).toBe(true);
+
+      trieNode.removeChild('a');
+      expect(trieNode.hasChild('a')).toBe(false);
+    });
+
+    it('should NOT delete child node if the child node has children', () => {
+      const trieNode = new TrieNode('c');
+      trieNode.addChild('a');
+      const childNode = trieNode.getChild('a');
+      childNode.addChild('r');
+
+      trieNode.removeChild('a');
+      expect(trieNode.hasChild('a')).toEqual(true);
+    });
+
+    it('should NOT delete child node if the child node completes a word', () => {
+      const trieNode = new TrieNode('c');
+      const IS_COMPLETE_WORD = true;
+      trieNode.addChild('a', IS_COMPLETE_WORD);
+
+      trieNode.removeChild('a');
+      expect(trieNode.hasChild('a')).toEqual(true);
+    });
+  });
+
   it('should get child nodes', () => {
     const trieNode = new TrieNode('c');
 


### PR DESCRIPTION
This PR adds the ability to delete words from the Trie data structure.

**NOTE - when deleting a word:**
- sets `trieNode.isCompleteWord` to `false` for the last character in the word
- deletes trieNodes in depth-first order (last character -> first character) 
- does NOT delete trieNodes if they have children
- does NOT delete trieNodes if `trieNode.isCompleteWord === true` (this is to prevent substring words from being deleted)

Example usage:
```js
const trie = new Trie();
trie.addWord('carpet');
trie.addWord('car');

trie.deleteWord('carpet');

trie.doesWordExist('carpet'); // returns false
trie.doesWordExist('car'); // returns true
```

Issue: #108
Refactored From PR: #168 