### PR TITLE
Fix minor typo on `segment-tree` readme

### DIFF
--- a/src/data-structures/tree/segment-tree/README.md
+++ b/src/data-structures/tree/segment-tree/README.md
@@ -40,7 +40,7 @@ and geographic information systems.
 Current implementation of Segment Tree implies that you may
 pass any binary (with two input params) function to it and 
 thus you're able to do range query for variety of functions.
-In tests you may fins examples of doing `min`, `max` and `sam` range
+In tests you may find examples of doing `min`, `max` and `sam` range
 queries on SegmentTree.
  
 ## References


### PR DESCRIPTION
Fixed a minor typo on `segment-tree` readme file:

- [`fins` => `find`](https://github.com/trekhleb/javascript-algorithms/compare/master...klauscfhq:master#diff-5c4ba01d9a803eba5858038fa21435f6)