### PR TITLE
Fix Stack pop comlexity to be O(1)

### DIFF
--- a/src/data-structures/stack/Stack.js
+++ b/src/data-structures/stack/Stack.js
@@ -4,7 +4,7 @@ export default class Stack {
   constructor() {
     // We're going to implement Stack based on LinkedList since these
     // structures are quite similar. Compare push/pop operations of the Stack
-    // with append/deleteTail operations of LinkedList.
+    // with prepend/deleteHead operations of LinkedList.
     this.linkedList = new LinkedList();
   }
 
@@ -12,8 +12,8 @@ export default class Stack {
    * @return {boolean}
    */
   isEmpty() {
-    // The stack is empty if its linked list doesn't have a tail.
-    return !this.linkedList.tail;
+    // The stack is empty if its linked list doesn't have a head.
+    return !this.linkedList.head;
   }
 
   /**
@@ -25,8 +25,8 @@ export default class Stack {
       return null;
     }
 
-    // Just read the value from the end of linked list without deleting it.
-    return this.linkedList.tail.value;
+    // Just read the value from the start of linked list without deleting it.
+    return this.linkedList.head.value;
   }
 
   /**
@@ -34,18 +34,18 @@ export default class Stack {
    */
   push(value) {
     // Pushing means to lay the value on top of the stack. Therefore let's just add
-    // the new value at the end of the linked list.
-    this.linkedList.append(value);
+    // the new value at the start of the linked list.
+    this.linkedList.prepend(value);
   }
 
   /**
    * @return {*}
    */
   pop() {
-    // Let's try to delete the last node (the tail) from the linked list.
-    // If there is no tail (the linked list is empty) just return null.
-    const removedTail = this.linkedList.deleteTail();
-    return removedTail ? removedTail.value : null;
+    // Let's try to delete the first node (the head) from the linked list.
+    // If there is no head (the linked list is empty) just return null.
+    const removedHead = this.linkedList.deleteHead();
+    return removedHead ? removedHead.value : null;
   }
 
   /**
@@ -54,8 +54,7 @@ export default class Stack {
   toArray() {
     return this.linkedList
       .toArray()
-      .map(linkedListNode => linkedListNode.value)
-      .reverse();
+      .map(linkedListNode => linkedListNode.value);
   }
 
   /**

--- a/src/data-structures/stack/__test__/Stack.test.js
+++ b/src/data-structures/stack/__test__/Stack.test.js
@@ -13,7 +13,7 @@ describe('Stack', () => {
     stack.push(1);
     stack.push(2);
 
-    expect(stack.toString()).toBe('1,2');
+    expect(stack.toString()).toBe('2,1');
   });
 
   it('should peek data from stack', () => {
@@ -58,7 +58,7 @@ describe('Stack', () => {
 
     const stringifier = value => `${value.key}:${value.value}`;
 
-    expect(stack.toString(stringifier)).toBe('key1:test1,key2:test2');
+    expect(stack.toString(stringifier)).toBe('key2:test2,key1:test1');
     expect(stack.pop().value).toBe('test2');
     expect(stack.pop().value).toBe('test1');
   });


### PR DESCRIPTION
* By definition Stack push/pop time complexity should be O(1).
* Fix is applied by removing head instead of tail in pop method.
* Push method now do preprend instead of append.
* Fix consistency between toString and toArray methods.