### PR TITLE
InsertionSort: use index to compare instead `undefined`

### DIFF
--- a/src/algorithms/sorting/insertion-sort/InsertionSort.js
+++ b/src/algorithms/sorting/insertion-sort/InsertionSort.js
@@ -14,16 +14,14 @@ export default class InsertionSort extends Sort {
       // Go and check if previous elements and greater then current one.
       // If this is the case then swap that elements.
       while (
-        array[currentIndex - 1] !== undefined
+        currentIndex - 1 >= 0
         && this.comparator.lessThan(array[currentIndex], array[currentIndex - 1])
       ) {
         // Call visiting callback.
         this.callbacks.visitingCallback(array[currentIndex - 1]);
 
         // Swap the elements.
-        const tmp = array[currentIndex - 1];
-        array[currentIndex - 1] = array[currentIndex];
-        array[currentIndex] = tmp;
+        [array[currentIndex - 1], array[currentIndex]] = [array[currentIndex], array[currentIndex - 1]]
 
         // Shift current index left.
         currentIndex -= 1;


### PR DESCRIPTION
1. use `currentIndex - 1 >= 0` instead `array[currentIndex - 1] !== undefined` in while-loop, I think it should be more readable.
2. swap value with destructuring assignment

some thoughts:
Since the for-loop in InsertionSort should start from `1`(in `0` it will just pass the while-loop), I think `for (let i = 1; i < array.length; i += 1)` would be a better idea.