### PR TITLE
Fix performance of bloom filter operations.

### DIFF
--- a/src/data-structures/bloom-filter/README.md
+++ b/src/data-structures/bloom-filter/README.md
@@ -44,7 +44,7 @@ In other words, the filter can take in items. When
 we go to check if an item has previously been
 inserted, it can tell us either "no" or "maybe".
 
-Both insertion and search are `O(1)` operations.
+Both insertion and search are `O(k)` operations.
 
 ## Making the filter
 


### PR DESCRIPTION
Time performance of a Bloom filter is on the order of the number of independent hash functions, `k`, not constant time.  