### PR TITLE
Update README.ja-JP.md

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -28,8 +28,8 @@ _Read this in other languages:_
 
 `B` - 初心者, `A` - 上級
 
-* `B` [リンクされたリスト](src/data-structures/linked-list)
-* `B` [二重リンクリスト](src/data-structures/doubly-linked-list)
+* `B` [連結リスト](src/data-structures/linked-list)
+* `B` [双方向リスト](src/data-structures/doubly-linked-list)
 * `B` [キュー](src/data-structures/queue)
 * `B` [スタック](src/data-structures/stack)
 * `B` [ハッシュ表](src/data-structures/hash-table)


### PR DESCRIPTION
In Japanese, the "連結リスト" seems to be more general than the "リンクされたリスト".
Furthermore,  the "双方向リスト" seems to be more general than the "二重リンクリスト".
https://ja.wikipedia.org/wiki/%E9%80%A3%E7%B5%90%E3%83%AA%E3%82%B9%E3%83%88