### PR TITLE
Fix japanese-translation typo

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -143,7 +143,7 @@ _Read this in other languages:_
 ### Paradigmによるアルゴリズム
 
 アルゴリズムパラダイムは、あるクラスのアルゴリズムの設計の基礎をなす一般的な方法またはアプローチである。それは、アルゴリズムがコンピュータプログラムよりも高い抽象であるのと同様に、アルゴリズムの概念よりも高い抽象である。
-* **ブルートフォース** - べての可能性を見て最適なソリューションを選択する
+* **ブルートフォース** - すべての可能性を見て最適なソリューションを選択する
   * `B` [線形探索](src/algorithms/search/linear-search)
   * `B` [レインテラス](src/algorithms/uncategorized/rain-terraces) - 雨水問題
   * `B` [Recursive Staircase](src/algorithms/uncategorized/recursive-staircase) - 先頭に到達する方法の数を数えます


### PR DESCRIPTION
"べて" is a typo for "すべて".