### PR TITLE
Graph customization

### DIFF
--- a/src/data-structures/graph/Graph.js
+++ b/src/data-structures/graph/Graph.js
@@ -13,7 +13,13 @@ export default class Graph {
    * @returns {Graph}
    */
   addVertex(newVertex) {
-    this.vertices[newVertex.getKey()] = newVertex;
+    const key = newVertex.getKey();
+
+    if (this.vertices[key]) {
+      throw new Error('Vertex has already been added before');
+    }
+
+    this.vertices[key] = newVertex;
 
     return this;
   }

--- a/src/data-structures/graph/GraphEdge.js
+++ b/src/data-structures/graph/GraphEdge.js
@@ -2,22 +2,27 @@ export default class GraphEdge {
   /**
    * @param {GraphVertex} startVertex
    * @param {GraphVertex} endVertex
-   * @param {number} [weight=1]
+   * @param {number} [weight=0]
+   * @param key
    */
-  constructor(startVertex, endVertex, weight = 0) {
+  constructor(startVertex, endVertex, weight = 0, key = null) {
     this.startVertex = startVertex;
     this.endVertex = endVertex;
     this.weight = weight;
+    this.key = key;
   }
 
-  /**
-   * @return {string}
-   */
   getKey() {
+    if (this.key) {
+      return this.key;
+    }
+
     const startVertexKey = this.startVertex.getKey();
     const endVertexKey = this.endVertex.getKey();
 
-    return `${startVertexKey}_${endVertexKey}`;
+    this.key = `${startVertexKey}_${endVertexKey}`;
+
+    return this.key;
   }
 
   /**
@@ -35,6 +40,6 @@ export default class GraphEdge {
    * @return {string}
    */
   toString() {
-    return this.getKey();
+    return this.getKey().toString();
   }
 }

--- a/src/data-structures/graph/GraphVertex.js
+++ b/src/data-structures/graph/GraphVertex.js
@@ -133,6 +133,6 @@ export default class GraphVertex {
    * @returns {string}
    */
   toString(callback) {
-    return callback ? callback(this.value) : `${this.value}`;
+    return callback ? callback(this.value).toString() : this.value.toString();
   }
 }

--- a/src/data-structures/graph/__test__/Graph.test.js
+++ b/src/data-structures/graph/__test__/Graph.test.js
@@ -158,6 +158,19 @@ describe('Graph', () => {
     expect(addSameEdgeTwice).toThrow();
   });
 
+  it('should throw an error when trying to add vertex twice', () => {
+    function addSameEdgeTwice() {
+      const graph = new Graph(true);
+      const vertexA = new GraphVertex('A');
+
+      graph
+        .addVertex(vertexA)
+        .addVertex(vertexA);
+    }
+
+    expect(addSameEdgeTwice).toThrow();
+  });
+
   it('should return the list of all added edges', () => {
     const graph = new Graph(true);
 

--- a/src/data-structures/graph/__test__/GraphEdge.test.js
+++ b/src/data-structures/graph/__test__/GraphEdge.test.js
@@ -7,8 +7,6 @@ describe('GraphEdge', () => {
     const endVertex = new GraphVertex('B');
     const edge = new GraphEdge(startVertex, endVertex);
 
-    expect(edge.getKey()).toBe('A_B');
-    expect(edge.toString()).toBe('A_B');
     expect(edge.startVertex).toEqual(startVertex);
     expect(edge.endVertex).toEqual(endVertex);
     expect(edge.weight).toEqual(0);
@@ -38,5 +36,19 @@ describe('GraphEdge', () => {
     expect(edge.startVertex).toEqual(vertexB);
     expect(edge.endVertex).toEqual(vertexA);
     expect(edge.weight).toEqual(10);
+  });
+
+  it('should return edges names as key', () => {
+    const edge = new GraphEdge(new GraphVertex('A'), new GraphVertex('B'), 0);
+
+    expect(edge.getKey()).toBe('A_B');
+    expect(edge.toString()).toBe('A_B');
+  });
+
+  it('should return custom key if defined', () => {
+    const edge = new GraphEdge(new GraphVertex('A'), new GraphVertex('B'), 0, 'custom_key');
+
+    expect(edge.getKey()).toEqual('custom_key');
+    expect(edge.toString()).toEqual('custom_key');
   });
 });

--- a/src/data-structures/graph/__test__/GraphEdge.test.js
+++ b/src/data-structures/graph/__test__/GraphEdge.test.js
@@ -51,4 +51,15 @@ describe('GraphEdge', () => {
     expect(edge.getKey()).toEqual('custom_key');
     expect(edge.toString()).toEqual('custom_key');
   });
+
+  it('should execute toString on key  when calling toString on edge', () => {
+    const customKey = {
+      toString() { return 'custom_key'; },
+    };
+
+    const edge = new GraphEdge(new GraphVertex('A'), new GraphVertex('B'), 0, customKey);
+
+    expect(edge.getKey()).toEqual(customKey);
+    expect(edge.toString()).toEqual('custom_key');
+  });
 });

--- a/src/data-structures/graph/__test__/GraphVertex.test.js
+++ b/src/data-structures/graph/__test__/GraphVertex.test.js
@@ -185,4 +185,20 @@ describe('GraphVertex', () => {
 
     expect(vertexA.getEdges().length).toEqual(3);
   });
+
+  it('should execute callback when passed to toString', () => {
+    const vertex = new GraphVertex('A');
+
+    expect(vertex.toString(() => 'B')).toEqual('B');
+  });
+
+  it('should execute toString on value when calling toString on vertex', () => {
+    const value = {
+      toString() { return 'A'; },
+    };
+
+    const vertex = new GraphVertex(value);
+
+    expect(vertex.toString()).toEqual('A');
+  });
 });


### PR DESCRIPTION
* Allow graph edges with custom keys. This is important if we have two edges connected to the same vertices but having a different weight. We could have used the weight in the name, but as conceptually two edges could also have the same vertices and weight, I think it's a better idea to propose the user a way to make sure this edge case (pun intended) doesn't happen.
* Vertex can be converted to string, so I made sure that the `toString()` method is called, in case we have objects convertible to strings. The native `toString()` implementation might throw exceptions as expected.
* Edge key is now sure to be correctly converted to string too.
* We currently can't add an edge twice to a graph, I also added support for not adding a vertex twice.