### PR TITLE
Fix README typo

### DIFF
--- a/src/data-structures/tree/segment-tree/README.md
+++ b/src/data-structures/tree/segment-tree/README.md
@@ -43,7 +43,7 @@ and geographic information systems.
 Current implementation of Segment Tree implies that you may
 pass any binary (with two input params) function to it and 
 thus you're able to do range query for variety of functions.
-In tests you may find examples of doing `min`, `max` and `sam` range
+In tests you may find examples of doing `min`, `max` and `sum` range
 queries on SegmentTree.
  
 ## References

--- a/src/data-structures/tree/segment-tree/README.pt-BR.md
+++ b/src/data-structures/tree/segment-tree/README.pt-BR.md
@@ -39,7 +39,7 @@ A implementação atual da Árvore de Segmentos implica que você pode passar
 qualquer função binária (com dois parâmetros de entradas) e então, você
 será capaz de realizar consultas de intervalos para uma variedade de funções.
 Nos testes você poderá encontrar exemplos realizando `min`, `max` e consultas de
-intervalo `sam` na árvore segmentada (SegmentTree).
+intervalo `sum` na árvore segmentada (SegmentTree).
  
 ## Referências
 


### PR DESCRIPTION
`sam` should be `sum` as a type of range query, which is correctly spelled in the test file.