### PR TITLE
Fix typo in comment

### DIFF
--- a/src/data-structures/tree/red-black-tree/RedBlackTree.js
+++ b/src/data-structures/tree/red-black-tree/RedBlackTree.js
@@ -155,7 +155,7 @@ export default class RedBlackTree extends BinarySearchTree {
       parentNode.parent = null;
     }
 
-    // Swap colors of granParent and parent nodes.
+    // Swap colors of grandParentNode and parentNode.
     this.swapNodeColors(parentNode, grandParentNode);
 
     // Return new root node.


### PR DESCRIPTION
Simple change to fix the typo in a comment in RedBlackTree.js

This is to address issue #528