### PR TITLE
Fix typo in tree BFS testcase name

### DIFF
--- a/src/algorithms/tree/breadth-first-search/__test__/breadthFirstSearch.test.js
+++ b/src/algorithms/tree/breadth-first-search/__test__/breadthFirstSearch.test.js
@@ -2,7 +2,7 @@ import BinaryTreeNode from '../../../../data-structures/tree/BinaryTreeNode';
 import breadthFirstSearch from '../breadthFirstSearch';
 
 describe('breadthFirstSearch', () => {
-  it('should perform DFS operation on tree', () => {
+  it('should perform BFS operation on tree', () => {
     const nodeA = new BinaryTreeNode('A');
     const nodeB = new BinaryTreeNode('B');
     const nodeC = new BinaryTreeNode('C');


### PR DESCRIPTION
There was a small typo in the name of one of the tests. 