### PR TITLE
Refactored merge sort to use array pointers instead of .shift()

### DIFF
--- a/src/algorithms/sorting/merge-sort/MergeSort.js
+++ b/src/algorithms/sorting/merge-sort/MergeSort.js
@@ -1,4 +1,4 @@
-import Sort from '../Sort';
+import Sort from "../Sort";
 
 export default class MergeSort extends Sort {
   sort(originalArray) {
@@ -24,36 +24,42 @@ export default class MergeSort extends Sort {
   }
 
   mergeSortedArrays(leftArray, rightArray) {
-    let sortedArray = [];
+    const sortedArray = [];
 
-    // In case if arrays are not of size 1.
-    while (leftArray.length && rightArray.length) {
-      let minimumElement = null;
+    // Use array pointers to exclude old elements after they have been added to the sorted array
+    let leftIndex = 0;
+    let rightIndex = 0;
 
-      // Find minimum element of two arrays.
-      if (this.comparator.lessThanOrEqual(leftArray[0], rightArray[0])) {
-        minimumElement = leftArray.shift();
+    while (leftIndex < leftArray.length && rightIndex < rightArray.length) {
+      // Find the minimum element between the left and right array
+      if (
+        this.comparator.lessThanOrEqual(
+          leftArray[leftIndex],
+          rightArray[rightIndex]
+        )
+      ) {
+        sortedArray.push(leftArray[leftIndex]);
+
+        // Increment index pointer to the right
+        leftIndex += 1;
+
+        // Call visiting callback.
+        this.callbacks.visitingCallback(leftArray[leftIndex]);
       } else {
-        minimumElement = rightArray.shift();
+        sortedArray.push(rightArray[rightIndex]);
+
+        // Increment index pointer to the right
+        rightIndex += 1;
+
+        // Call visiting callback.
+        this.callbacks.visitingCallback(rightArray[rightIndex]);
       }
-
-      // Call visiting callback.
-      this.callbacks.visitingCallback(minimumElement);
-
-      // Push the minimum element of two arrays to the sorted array.
-      sortedArray.push(minimumElement);
     }
 
-    // If one of two array still have elements we need to just concatenate
-    // this element to the sorted array since it is already sorted.
-    if (leftArray.length) {
-      sortedArray = sortedArray.concat(leftArray);
-    }
-
-    if (rightArray.length) {
-      sortedArray = sortedArray.concat(rightArray);
-    }
-
-    return sortedArray;
+    // There will be one element remaining from either the left OR the right
+    // Concatenate the remaining element into the sorted array
+    return sortedArray
+      .concat(leftArray.slice(leftIndex))
+      .concat(rightArray.slice(rightIndex));
   }
 }


### PR DESCRIPTION
The previous implementation of merge sort used the array.shift() method to merge elements from leftArray and rightArray into the sorted array. This is a bad practice, because JavaScript's implementation of the Array.prototype.shift() method is, at worst, O(n) runtime complexity, where n is the length of the array being sorted (in order to move n elements of an array over by 1, all n elements of the array must typically be touched).

To work around this, I refactored merge sort to use array pointers instead. Now, after an element has been added to the sorted array, rather than delete it from the old array and shift the entire old array over, the array index pointer is just incremented to the right by one to avoid the old element. This will always require O(1) runtime complexity, which is a significant performance boost.

I also added two simple concat() statements to the returned sortedArray value, because the length of the left and right arrays can no longer be used to determine if an element is still "dangling" (needing to be added to the sorted array).

All tests passed after my changes.

[Quick Stack Overflow info on JavaScript array method runtime complexities](https://stackoverflow.com/questions/22614237/javascript-runtime-complexity-of-array-functions)