### PR TITLE
added the condition to handle negative integers for fastPowering algorithm.

### DIFF
--- a/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
+++ b/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
@@ -19,5 +19,8 @@ describe('fastPowering', () => {
     expect(fastPowering(16, 16)).toBe(18446744073709552000);
     expect(fastPowering(7, 21)).toBe(558545864083284000);
     expect(fastPowering(100, 9)).toBe(1000000000000000000);
+    expect(fastPowering(5, -5)).toBe(0.0003200000000000002);
+    expect(fastPowering(-5, 5)).toBe(-3125);
+    expect(fastPowering(-5, -5)).toBe(-0.0003200000000000002);
   });
 });

--- a/src/algorithms/math/fast-powering/fastPowering.js
+++ b/src/algorithms/math/fast-powering/fastPowering.js
@@ -13,6 +13,13 @@ export default function fastPowering(base, power) {
     // Anything that is raised to the power of zero is 1.
     return 1;
   }
+  
+  if(power<0){
+    power=power*-1;
+    base=1/base;
+   // console.log(base);
+    fastPowering(base,power);
+  }
 
   if (power % 2 === 0) {
     // If the power is even...


### PR DESCRIPTION
Issue:

Error:RangeError: Maximum call stack size exceeded #590

I have edited the fastpowering algorithm to handle negative integers and the test file to check the negative integers condition.