### PR TITLE
Optimize Insertion Sort, update tests, & correct comments

### DIFF
--- a/src/algorithms/sorting/insertion-sort/InsertionSort.js
+++ b/src/algorithms/sorting/insertion-sort/InsertionSort.js
@@ -5,14 +5,14 @@ export default class InsertionSort extends Sort {
     const array = [...originalArray];
 
     // Go through all array elements...
-    for (let i = 0; i < array.length; i += 1) {
+    for (let i = 1; i < array.length; i += 1) {
       let currentIndex = i;
 
       // Call visiting callback.
       this.callbacks.visitingCallback(array[i]);
 
-      // Go and check if previous elements and greater then current one.
-      // If this is the case then swap that elements.
+      // Check if previous element is greater than current element.
+      // If so, swap the two elements.
       while (
         array[currentIndex - 1] !== undefined
         && this.comparator.lessThan(array[currentIndex], array[currentIndex - 1])

--- a/src/algorithms/sorting/insertion-sort/__test__/InsertionSort.test.js
+++ b/src/algorithms/sorting/insertion-sort/__test__/InsertionSort.test.js
@@ -8,10 +8,10 @@ import {
 } from '../../SortTester';
 
 // Complexity constants.
-const SORTED_ARRAY_VISITING_COUNT = 20;
-const NOT_SORTED_ARRAY_VISITING_COUNT = 101;
-const REVERSE_SORTED_ARRAY_VISITING_COUNT = 210;
-const EQUAL_ARRAY_VISITING_COUNT = 20;
+const SORTED_ARRAY_VISITING_COUNT = 19;
+const NOT_SORTED_ARRAY_VISITING_COUNT = 100;
+const REVERSE_SORTED_ARRAY_VISITING_COUNT = 209;
+const EQUAL_ARRAY_VISITING_COUNT = 19;
 
 describe('InsertionSort', () => {
   it('should sort array', () => {


### PR DESCRIPTION
# Insertion Sort Clean Up

## Algorithm Change
The existing insertion sort implementation began by iterating from
0 until the end of the array, but it is only necessary to
iterate from 1 until the end of the array, since at the
0th index, there is nothing to compare to the left of
the element.

I also corrected the grammar/wording of the comments.


## Test Change
In order to complete this change, I also had to update the tests
to reflect the fact that the algorithm visits each index 1 less
time.

## Diagnostics
Passed all tests and linting.