### PR TITLE
Adding single quotes type to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+quote_type = single


### PR DESCRIPTION
In VSCode with prettier extension the format on save changes automatically to double quotes, so I add one line in .editorconfig to prevent it. 