### PR TITLE
Null Reference Exception

### DIFF
--- a/src/data-structures/linked-list/README.md
+++ b/src/data-structures/linked-list/README.md
@@ -104,8 +104,9 @@ Remove(head, value)
     if n.next = tail
       tail ← n
       tail.next = null
+    else
+      n.next ← n.next.next
     end if
-    n.next ← n.next.next
     return true
   end if
   return false


### PR DESCRIPTION
When `n.next = tail` is true, we assign `n` to `tail` and `null` to `tail.next`, so `n.next` also becomes `null`. Then we assign `n.next.next` (because now `n.next` is `null`), we try to get `next` of `null`. That is why we should add an `else` case to check if `n.next` is not equal to `tail`.