### PR TITLE
Tweaked get function of HashTable

### DIFF
--- a/src/data-structures/hash-table/HashTable.js
+++ b/src/data-structures/hash-table/HashTable.js
@@ -85,7 +85,11 @@ export default class HashTable {
    * @return {*}
    */
   get(key) {
-    const bucketLinkedList = this.buckets[this.hash(key)];
+    const computedHash = this.keys[key]?? null;
+    if(computedHash === null){
+       return undefined;
+    }
+    const bucketLinkedList = this.buckets[computedHash];
     const node = bucketLinkedList.find({ callback: (nodeValue) => nodeValue.key === key });
 
     return node ? node.value.value : undefined;


### PR DESCRIPTION
In case of key on present in table, now don't need to be compute hash for that key, then check corresponding list from bucket for that hash that key is present instead now agent will return expected undefined once there is no hash value present at fast lookup keys object