### PR TITLE
chore(docs): Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Read this in other languages:_
 [_Português_](README.pt-BR.md),
 [_Русский_](README.ru-RU.md),
 [_Türk_](README.tr-TR.md),
-[_Italiana_](README.it-IT.md),
+[_Italiano_](README.it-IT.md),
 [_Bahasa Indonesia_](README.id-ID.md),
 [_Українська_](README.uk-UA.md),
 [_Arabic_](README.ar-AR.md),


### PR DESCRIPTION
The name of the language is "Italiano" (ending in -o), it becomes "Italiana" only when it has to match the genre of "lingua" ("language") which is feminine.

So you could translate "Italian language" as either "lingua italiana" or "italiano".

Pretty much the same happens, for example, in Spanish: you could say either "lengua española" or just "español".