### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/algorithms/cryptography/polynomial-hash/__test__/PolynomialHash.test.js
+++ b/src/algorithms/cryptography/polynomial-hash/__test__/PolynomialHash.test.js
@@ -21,12 +21,12 @@ describe('PolynomialHash', () => {
 
         // Check hashing for different word lengths.
         frameSizes.forEach((frameSize) => {
-          let previousWord = text.substr(0, frameSize);
+          let previousWord = text.slice(0, frameSize);
           let previousHash = polynomialHash.hash(previousWord);
 
           // Shift frame through the whole text.
           for (let frameShift = 1; frameShift < (text.length - frameSize); frameShift += 1) {
-            const currentWord = text.substr(frameShift, frameSize);
+            const currentWord = text.slice(frameShift, frameShift + frameSize);
             const currentHash = polynomialHash.hash(currentWord);
             const currentRollingHash = polynomialHash.roll(previousHash, previousWord, currentWord);
 

--- a/src/algorithms/cryptography/polynomial-hash/__test__/SimplePolynomialHash.test.js
+++ b/src/algorithms/cryptography/polynomial-hash/__test__/SimplePolynomialHash.test.js
@@ -18,12 +18,12 @@ describe('PolynomialHash', () => {
 
       // Check hashing for different word lengths.
       frameSizes.forEach((frameSize) => {
-        let previousWord = text.substr(0, frameSize);
+        let previousWord = text.slice(0, frameSize);
         let previousHash = polynomialHash.hash(previousWord);
 
         // Shift frame through the whole text.
         for (let frameShift = 1; frameShift < (text.length - frameSize); frameShift += 1) {
-          const currentWord = text.substr(frameShift, frameSize);
+          const currentWord = text.slice(frameShift, frameShift + frameSize);
           const currentHash = polynomialHash.hash(currentWord);
           const currentRollingHash = polynomialHash.roll(previousHash, previousWord, currentWord);
 

--- a/src/algorithms/string/rabin-karp/rabinKarp.js
+++ b/src/algorithms/string/rabin-karp/rabinKarp.js
@@ -32,7 +32,7 @@ export default function rabinKarp(text, word) {
     // In case of hash collision the strings may not be equal.
     if (
       wordHash === currentFrameHash
-      && text.substr(charIndex, word.length) === word
+      && text.slice(charIndex, charIndex + word.length) === word
     ) {
       return charIndex;
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.