### PR TITLE
Fix: Fix Typo on line 280

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ npm test -- 'LinkedList'
 
 **Troubleshooting**
 
-In case if linting or testing is failing try to delete the `node_modules` folder and re-install npm packages:
+In case of linting or testing is failing try to delete the `node_modules` folder and re-install npm packages:
 
 ```
 rm -rf ./node_modules


### PR DESCRIPTION
In line 280 of the README.md it says 'In case if linting or testing is failing'
It should say 'In case of linting or testing is failing'