### PR TITLE
Fix BUG in graph reverse method & Add needed tests

### DIFF
--- a/src/data-structures/graph/Graph.js
+++ b/src/data-structures/graph/Graph.js
@@ -144,6 +144,7 @@ export default class Graph {
    */
   reverse() {
     /** @param {GraphEdge} edge */
+    const reversedEdges = [];
     this.getAllEdges().forEach((edge) => {
       // Delete straight edge from graph and from vertices.
       this.deleteEdge(edge);
@@ -151,7 +152,11 @@ export default class Graph {
       // Reverse the edge.
       edge.reverse();
 
-      // Add reversed edge back to the graph and its vertices.
+      // Add reversed edge to the list of reversed edges.
+      reversedEdges.push(edge);
+    });
+    reversedEdges.forEach((edge) => {
+      // Add reversed edge to the graph.
       this.addEdge(edge);
     });
 

--- a/src/data-structures/graph/__test__/Graph.test.js
+++ b/src/data-structures/graph/__test__/Graph.test.js
@@ -318,6 +318,35 @@ describe('Graph', () => {
     expect(graph.getNeighbors(vertexD)[0].getKey()).toBe(vertexC.getKey());
   });
 
+  it('should be possible to reverse directed graph with cycle of lenght two', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBA = new GraphEdge(vertexB, vertexA);
+
+    const graph = new Graph(true);
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBA);
+
+    expect(graph.toString()).toBe('A,B');
+    expect(graph.getAllEdges().length).toBe(2);
+    expect(graph.getNeighbors(vertexA).length).toBe(1);
+    expect(graph.getNeighbors(vertexA)[0].getKey()).toBe(vertexB.getKey());
+    expect(graph.getNeighbors(vertexB).length).toBe(1);
+    expect(graph.getNeighbors(vertexB)[0].getKey()).toBe(vertexA.getKey());
+
+    graph.reverse();
+
+    expect(graph.toString()).toBe('A,B');
+    expect(graph.getAllEdges().length).toBe(2);
+    expect(graph.getNeighbors(vertexA).length).toBe(1);
+    expect(graph.getNeighbors(vertexA)[0].getKey()).toBe(vertexB.getKey());
+    expect(graph.getNeighbors(vertexB).length).toBe(1);
+    expect(graph.getNeighbors(vertexB)[0].getKey()).toBe(vertexA.getKey());
+  });
+
   it('should return vertices indices', () => {
     const vertexA = new GraphVertex('A');
     const vertexB = new GraphVertex('B');


### PR DESCRIPTION
This PR fix the issue in #873.

The issue was in the old reverse method, edges reversed one by one and this was making issue for graphs with cycle of length 2. For example, when graph with only two edges AB and BA was reversing, on reversing AB, BA was exist and there will be crash.