### PR TITLE
Clear from advertising text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # JavaScript Algorithms and Data Structures
 
-> 🇺🇦 UKRAINE [IS BEING ATTACKED](https://war.ukraine.ua/) BY RUSSIAN ARMY. CIVILIANS ARE GETTING KILLED. RESIDENTIAL AREAS ARE GETTING BOMBED.
-> - Help Ukraine via [National Bank of Ukraine](https://bank.gov.ua/en/news/all/natsionalniy-bank-vidkriv-spetsrahunok-dlya-zboru-koshtiv-na-potrebi-armiyi)
-> - Help Ukraine via [SaveLife](https://savelife.in.ua/en/donate-en/) fund
-> - More info on [war.ukraine.ua](https://war.ukraine.ua/) and [MFA of Ukraine](https://twitter.com/MFA_Ukraine)
-
-<hr/>
-
 [![CI](https://github.com/trekhleb/javascript-algorithms/workflows/CI/badge.svg)](https://github.com/trekhleb/javascript-algorithms/actions?query=workflow%3ACI+branch%3Amaster)
 [![codecov](https://codecov.io/gh/trekhleb/javascript-algorithms/branch/master/graph/badge.svg)](https://codecov.io/gh/trekhleb/javascript-algorithms)
 


### PR DESCRIPTION
_**What changed**_
* Removed content from Readme.MD

_**Purposes of changes**_

* GitHub is a platform primarily used for software development and collaboration. Its main purpose is to provide a space for developers to share, collaborate on, and improve upon code. The README.MD file is an important part of this process, as it serves as the primary source of information for users and contributors about a particular project.

* Including political statements or content in the README.MD file of a project can be divisive and disruptive to the collaborative nature of the platform. It can also make users and contributors who disagree with the political statements or content uncomfortable or unwelcome. This can lead to a toxic environment that discourages participation and collaboration.

* Furthermore, political statements or content in the README.MD file can also be seen as a form of advertising or promotion, which is not the intended purpose of the platform. This can lead to confusion among users and contributors, as they may not be aware of the political agenda or beliefs of the project.

* In addition, one can argue that political statements or content in the README.MD file can also distract from the main purpose of the project, which is to provide information and instructions about the code. This can make it difficult for users and contributors to find the information they need to use or contribute to the project.

* In light of these considerations, it is important to keep the README.MD file free of political statements or content in order to maintain a productive and inclusive environment for all users and contributors.