### PR TITLE
Update peek() method to read from tail.

### DIFF
--- a/src/data-structures/stack/Stack.js
+++ b/src/data-structures/stack/Stack.js
@@ -26,7 +26,7 @@ export default class Stack {
     }
 
     // Just read the value from the start of linked list without deleting it.
-    return this.linkedList.head.value;
+    return this.linkedList.tail.value;
   }
 
   /**


### PR DESCRIPTION
Peeking at the element should be done from the tail rather than the head.