### PR TITLE
set tail as newNode if currentNode is the tail

### DIFF
--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -75,6 +75,9 @@ export default class LinkedList {
       if (currentNode) {
         newNode.next = currentNode.next;
         currentNode.next = newNode;
+        if (this.tail === currentNode) {
+          this.tail = newNode;
+        }
       } else {
         if (this.tail) {
           this.tail.next = newNode;

--- a/src/data-structures/linked-list/__test__/LinkedList.test.js
+++ b/src/data-structures/linked-list/__test__/LinkedList.test.js
@@ -43,8 +43,10 @@ describe('LinkedList', () => {
     linkedList.insert(2, 1);
     linkedList.insert(1, -7);
     linkedList.insert(10, 9);
-
-    expect(linkedList.toString()).toBe('1,4,2,3,10');
+    linkedList.insert(7, 5);
+    expect(linkedList.toString()).toBe('1,4,2,3,10,7');
+    expect(linkedList.head.toString()).toBe('1');
+    expect(linkedList.tail.toString()).toBe('7');
   });
 
   it('should delete node by value from linked list', () => {

--- a/src/data-structures/linked-list/__test__/LinkedList.test.js
+++ b/src/data-structures/linked-list/__test__/LinkedList.test.js
@@ -43,6 +43,9 @@ describe('LinkedList', () => {
     linkedList.insert(2, 1);
     linkedList.insert(1, -7);
     linkedList.insert(10, 9);
+
+    expect(linkedList.toString()).toBe('1,4,2,3,10');
+
     linkedList.insert(7, 5);
     expect(linkedList.toString()).toBe('1,4,2,3,10,7');
     expect(linkedList.head.toString()).toBe('1');

--- a/src/data-structures/linked-list/__test__/LinkedList.test.js
+++ b/src/data-structures/linked-list/__test__/LinkedList.test.js
@@ -45,11 +45,18 @@ describe('LinkedList', () => {
     linkedList.insert(10, 9);
 
     expect(linkedList.toString()).toBe('1,4,2,3,10');
+  });
 
-    linkedList.insert(7, 5);
-    expect(linkedList.toString()).toBe('1,4,2,3,10,7');
-    expect(linkedList.head.toString()).toBe('1');
-    expect(linkedList.tail.toString()).toBe('7');
+  it('should insert and maintain head and tail', () => {
+    const linkedList = new LinkedList();
+
+    linkedList.insert(2, 0);
+    linkedList.insert(3, 1);
+    linkedList.insert(4, 2);
+
+    expect(linkedList.toString()).toBe('2,3,4');
+    expect(linkedList.head.toString()).toBe('2');
+    expect(linkedList.tail.toString()).toBe('4');
   });
 
   it('should delete node by value from linked list', () => {


### PR DESCRIPTION
closes #1016
closes #1004

### To reproduce

1. Populate the list normally, insert few values.
2. call [insert](https://github.com/trekhleb/javascript-algorithms/blob/019c07e9e3bdd804b6d2ba2adab42f69cfc25bbd/src/data-structures/linked-list/LinkedList.js#L62) with `rawIndex` equals to last node index + 1 (exactly where new node would fit)

### Expectation
`this.tail` should point to the last added value as it has rawIndex as previous tail + 1

### Behaviour
`this.tail` points to the previous tail.

### Fix

If `currentNode` is the tail then `newNode` should be the new `tail`, as in this scenario `currentNode` will have `newNode` as its `next`