### PR TITLE
I added size func. for some data structures

### DIFF
--- a/src/data-structures/doubly-linked-list/DoublyLinkedList.js
+++ b/src/data-structures/doubly-linked-list/DoublyLinkedList.js
@@ -213,6 +213,10 @@ export default class DoublyLinkedList {
     return nodes;
   }
 
+  size() {
+    return this.toArray().length;
+  }
+
   /**
    * @param {*[]} values - Array of values that need to be converted to linked list.
    * @return {DoublyLinkedList}

--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -233,6 +233,13 @@ export default class LinkedList {
 
     return nodes;
   }
+  
+  /**
+   * @return {number}
+   */
+  size() {
+    return this.toArray().length;
+  }
 
   /**
    * @param {function} [callback]

--- a/src/data-structures/queue/Queue.js
+++ b/src/data-structures/queue/Queue.js
@@ -48,6 +48,14 @@ export default class Queue {
   }
 
   /**
+   * @return {number}
+   */
+  size() {
+    return this.linkedList.size();
+  }
+
+  
+  /**
    * @param [callback]
    * @return {string}
    */

--- a/src/data-structures/stack/Stack.js
+++ b/src/data-structures/stack/Stack.js
@@ -49,6 +49,13 @@ export default class Stack {
   }
 
   /**
+   * @return {number}
+   */
+  size() {
+    return this.linkedList.size();
+  }
+
+  /**
    * @return {*[]}
    */
   toArray() {


### PR DESCRIPTION
I realized that we cannot access size of some structurest directly like stack, queue. We were have to access size by other objects like linkedlist.toArray().size. That is why i added size func. inside linkedlist using toArray func and i called size func. of linkedlist inside other structures.(stack, queue, doublylindkedlist.) Now we can direct access size inside data structures like stack and queue.