### PR TITLE
fix(fastPowering): check when number is raided to power of one

### DIFF
--- a/src/algorithms/math/fast-powering/fastPowering.js
+++ b/src/algorithms/math/fast-powering/fastPowering.js
@@ -9,6 +9,11 @@
  * @return {number}
  */
 export default function fastPowering(base, power) {
+  if (power === 1) {
+    // Any number raised to the power of one is always that number
+    return base;
+  }
+
   if (power === 0) {
     // Anything that is raised to the power of zero is 1.
     return 1;


### PR DESCRIPTION
The function didnt check when power is one so unnecessarily was going though multiplying base by ones 