### PR TITLE
BinaryTreeNode.js  height() gives one less than tree's height.

### DIFF
--- a/src/data-structures/tree/BinaryTreeNode.js
+++ b/src/data-structures/tree/BinaryTreeNode.js
@@ -26,7 +26,7 @@ export default class BinaryTreeNode {
       return 0;
     }
 
-    return this.left.height + 1;
+    return this.left.height;
   }
 
   /**
@@ -37,14 +37,14 @@ export default class BinaryTreeNode {
       return 0;
     }
 
-    return this.right.height + 1;
+    return this.right.height;
   }
 
   /**
    * @return {number}
    */
   get height() {
-    return Math.max(this.leftHeight, this.rightHeight);
+    return Math.max(this.leftHeight, this.rightHeight) + 1;
   }
 
   /**


### PR DESCRIPTION
The height of the tree is the number of edges in the tree from the root to the deepest node. 

height right now gives one less than the total number of the edges, small tweek made will fix it.