### PR TITLE
Update PriorityQueue.js

### DIFF
--- a/src/data-structures/priority-queue/PriorityQueue.js
+++ b/src/data-structures/priority-queue/PriorityQueue.js
@@ -22,7 +22,7 @@ export default class PriorityQueue extends MinHeap {
    * @param {number} [priority] - items priority.
    * @return {PriorityQueue}
    */
-  add(item, priority = 0) {
+  add(item, priority = item) {
     this.priorities.set(item, priority);
     super.add(item);
     return this;


### PR DESCRIPTION
Changed the default priority of a item to value of the item if the priority is not provided manually in the add() method.
Now it resolves the issue #1070
describe('priorityQueue Test:', () => {
 it('should return correct priorityQueue results:', () => {
    const pq = new PriorityQueue();
    pq.add(1);
    pq.add(2);
    pq.add(3);
    pq.add(4);
    expect(pq.toString()).toBe('1,2,3,4');
    expect(pq.poll()).toBe(1);
    expect(pq.poll()).toBe(2);
    expect(pq.poll()).toBe(3);
    expect(pq.poll()).toBe(4);
  });
});
It polls out values as 1,2,3,4