### PR TITLE
fix(heap): this is undefined

### DIFF
--- a/src/data-structures/heap/MaxHeapAdhoc.js
+++ b/src/data-structures/heap/MaxHeapAdhoc.js
@@ -7,7 +7,7 @@
 class MaxHeapAdhoc {
   constructor(heap = []) {
     this.heap = [];
-    heap.forEach(this.add);
+    heap.forEach((value) => this.add(value));
   }
 
   add(num) {

--- a/src/data-structures/heap/MinHeapAdhoc.js
+++ b/src/data-structures/heap/MinHeapAdhoc.js
@@ -7,7 +7,7 @@
 class MinHeapAdhoc {
   constructor(heap = []) {
     this.heap = [];
-    heap.forEach(this.add);
+    heap.forEach((value) => this.add(value));
   }
 
   add(num) {

--- a/src/data-structures/heap/__test__/MaxHeapAdhoc.test.js
+++ b/src/data-structures/heap/__test__/MaxHeapAdhoc.test.js
@@ -1,8 +1,8 @@
-import MaxHeap from '../MaxHeapAdhoc';
+import MaxHeapAdhoc from '../MaxHeapAdhoc';
 
 describe('MaxHeapAdhoc', () => {
   it('should create an empty max heap', () => {
-    const maxHeap = new MaxHeap();
+    const maxHeap = new MaxHeapAdhoc();
 
     expect(maxHeap).toBeDefined();
     expect(maxHeap.peek()).toBe(undefined);
@@ -10,7 +10,7 @@ describe('MaxHeapAdhoc', () => {
   });
 
   it('should add items to the heap and heapify it up', () => {
-    const maxHeap = new MaxHeap();
+    const maxHeap = new MaxHeapAdhoc();
 
     maxHeap.add(5);
     expect(maxHeap.isEmpty()).toBe(false);
@@ -44,7 +44,7 @@ describe('MaxHeapAdhoc', () => {
   });
 
   it('should poll items from the heap and heapify it down', () => {
-    const maxHeap = new MaxHeap();
+    const maxHeap = new MaxHeapAdhoc();
 
     maxHeap.add(5);
     maxHeap.add(3);
@@ -74,7 +74,7 @@ describe('MaxHeapAdhoc', () => {
   });
 
   it('should heapify down through the right branch as well', () => {
-    const maxHeap = new MaxHeap();
+    const maxHeap = new MaxHeapAdhoc();
 
     maxHeap.add(3);
     maxHeap.add(12);
@@ -87,5 +87,13 @@ describe('MaxHeapAdhoc', () => {
 
     expect(maxHeap.poll()).toBe(12);
     expect(maxHeap.toString()).toBe('11,3,10');
+  });
+
+  it('should create the max heap filled', () => {
+    const maxHeap = new MaxHeapAdhoc([3, 12, 10]);
+
+    expect(maxHeap).toBeDefined();
+    expect(maxHeap.peek()).toBe(12);
+    expect(maxHeap.isEmpty()).toBe(false);
   });
 });

--- a/src/data-structures/heap/__test__/MinHeapAdhoc.test.js
+++ b/src/data-structures/heap/__test__/MinHeapAdhoc.test.js
@@ -88,4 +88,12 @@ describe('MinHeapAdhoc', () => {
     expect(minHeap.poll()).toBe(3);
     expect(minHeap.toString()).toBe('10,11,12');
   });
+
+  it('should create the min heap filled', () => {
+    const minHeap = new MinHeapAdhoc([3, 12, 10]);
+
+    expect(minHeap).toBeDefined();
+    expect(minHeap.peek()).toBe(3);
+    expect(minHeap.isEmpty()).toBe(false);
+  });
 });


### PR DESCRIPTION
## What's the problem?
- `MaxHeapAdhoc` and `MinHeapAdhoc` constructor can get an array for filling the heap initially.
- And then the constructors execute this:
```js
this.heap.forEach(this.add);
```

- But It did occur this error:
  <img width="726" alt="스크린샷 2024-04-13 01 19 15" src="https://github.com/trekhleb/javascript-algorithms/assets/33178048/8c55ab48-69f8-4c1c-885a-8992e1914f6a">

- **The problem is that if passing `this.add` method literally, `this` in `add` method is `undefined`.**
- 
- This issue is confusing for the developers. **And your intend is that `MaxHeapAdhoc` and `MinHeapAdhoc` is used by developers easily**

https://github.com/trekhleb/javascript-algorithms/pull/1117

> This PR contains several minimalistic (by their functionalities and implementation) data structures like MinHeap, MaxHeap, and DisjointSet that don't have external dependencies and that are easy to copy-paste and use during the coding interview if allowed by the interviewer.

## How to fix
- Just use arrow function

```js
this.heap.forEach((value) => this.add(value));
```
