### PR TITLE
Shifted method has been changed

### DIFF
--- a/src/algorithms/math/bits/countSetBits.js
+++ b/src/algorithms/math/bits/countSetBits.js
@@ -10,8 +10,8 @@ export default function countSetBits(originalNumber) {
     // Add last bit of the number to the sum of set bits.
     setBitsCount += number & 1;
 
-    // Shift number right by one bit to investigate other bits.
-    number >>>= 1;
+    // Arithmetic Shift number right by one bit to investigate other bits.
+    number >>= 1;
   }
 
   return setBitsCount;


### PR DESCRIPTION
This PR has corrected the right shifted method (algorithmic method) in the function to preserve the sign of integer. 

Fixes #1152 