### PR TITLE
Enhance BinaryTreeNode: Add type checking for child nodes

### DIFF
--- a/src/data-structures/tree/BinaryTreeNode.js
+++ b/src/data-structures/tree/BinaryTreeNode.js
@@ -100,6 +100,12 @@ export default class BinaryTreeNode {
    * @return {BinaryTreeNode}
    */
   setLeft(node) {
+
+    // Check if it is a proper node.
+    if (node && !(node instanceof BinaryTreeNode)) {
+      throw new Error('The left node must be an instance of BinaryTreeNode');
+    }
+
     // Reset parent for left node since it is going to be detached.
     if (this.left) {
       this.left.parent = null;
@@ -121,6 +127,12 @@ export default class BinaryTreeNode {
    * @return {BinaryTreeNode}
    */
   setRight(node) {
+
+    // Check if it is a proper node.
+    if (node && !(node instanceof BinaryTreeNode)) {
+      throw new Error('The right node must be an instance of BinaryTreeNode');
+    }
+
     // Reset parent for right node since it is going to be detached.
     if (this.right) {
       this.right.parent = null;


### PR DESCRIPTION
### Summary

This pull request introduces type checking to the `setLeft` and `setRight` methods of the `BinaryTreeNode` class. The enhancement ensures that only instances of `BinaryTreeNode` can be assigned as children, which prevents potential bugs caused by invalid node assignments.

### Changes Made

- Added type checks to `setLeft` and `setRight` methods to ensure only `BinaryTreeNode` instances can be set as children.
- If an invalid node type is provided, an error is thrown to prevent incorrect usage.

### Why This Change is Necessary

Type safety is crucial in maintaining the integrity of the binary tree structure. Without these checks, there's a risk of assigning incompatible objects as child nodes, which could lead to unexpected behavior or errors in tree operations.

### Impact

These changes should not affect existing functionality but will enhance the robustness of the binary tree implementation.
