### PR TITLE
Return `longestIncreasingSubsequence` from `dpLongestIncreasingSubsequence`

### DIFF
--- a/src/algorithms/sets/longest-increasing-subsequence/__test__/dpLongestIncreasingSubsequence.test.js
+++ b/src/algorithms/sets/longest-increasing-subsequence/__test__/dpLongestIncreasingSubsequence.test.js
@@ -2,35 +2,20 @@ import dpLongestIncreasingSubsequence from '../dpLongestIncreasingSubsequence';
 
 describe('dpLongestIncreasingSubsequence', () => {
   it('should find longest increasing subsequence length', () => {
-    // Should be:
-    // 9 or
-    // 8 or
-    // 7 or
-    // 6 or
-    // ...
     expect(dpLongestIncreasingSubsequence([
       9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
-    ])).toBe(1);
+    ])).toStrictEqual([9]);
 
-    // Should be:
-    // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     expect(dpLongestIncreasingSubsequence([
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-    ])).toBe(10);
+    ])).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
-    // Should be:
-    // -1, 0, 2, 3
     expect(dpLongestIncreasingSubsequence([
       3, 4, -1, 0, 6, 2, 3,
-    ])).toBe(4);
+    ])).toStrictEqual([-1, 0, 2, 3]);
 
-    // Should be:
-    // 0, 2, 6, 9, 11, 15 or
-    // 0, 4, 6, 9, 11, 15 or
-    // 0, 2, 6, 9, 13, 15 or
-    // 0, 4, 6, 9, 13, 15
     expect(dpLongestIncreasingSubsequence([
       0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15,
-    ])).toBe(6);
+    ])).toStrictEqual([0, 2, 6, 9, 11, 15]);
   });
 });

--- a/src/algorithms/sets/longest-increasing-subsequence/dpLongestIncreasingSubsequence.js
+++ b/src/algorithms/sets/longest-increasing-subsequence/dpLongestIncreasingSubsequence.js
@@ -3,7 +3,7 @@
  * Complexity: O(n * n)
  *
  * @param {number[]} sequence
- * @return {number}
+ * @return {number[]}
  */
 export default function dpLongestIncreasingSubsequence(sequence) {
   // Create array with longest increasing substrings length and
@@ -49,5 +49,18 @@ export default function dpLongestIncreasingSubsequence(sequence) {
     }
   }
 
-  return longestIncreasingLength;
+  // Construct the longest increasing subsequence from the back to the front
+  let rightIndex = lengthsArray.findIndex((item) => item === longestIncreasingLength);
+  const longestIncreasingSubsequence = [];
+
+  while (rightIndex > -1) {
+    const leftIndex = lengthsArray.findLastIndex((item, idx) => (
+       item === lengthsArray[rightIndex] - 1 && idx < rightIndex
+    ));
+
+    longestIncreasingSubsequence.unshift(sequence[rightIndex]);
+    rightIndex = leftIndex;
+  }
+
+  return longestIncreasingSubsequence;
 }


### PR DESCRIPTION
The Longest Increasing Subsequence [README.md](https://github.com/trekhleb/javascript-algorithms/tree/master/src/algorithms/sets/longest-increasing-subsequence) and [dpLongestIncreasingSubsequence.test.js](https://github.com/trekhleb/javascript-algorithms/blob/master/src/algorithms/sets/longest-increasing-subsequence/__test__/dpLongestIncreasingSubsequence.test.js) give examples of the longest increasing subsequence that will be generated from various sequences:

> In the first 16 terms of the binary Van der Corput sequence
> 
> ```
> 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15
> ```
> 
> a longest increasing subsequence is
> 
> ```
> 0, 2, 6, 9, 11, 15.
> ```

However, the implemented algorithm only returns the length of the longest increasing subsequence, not the subsequence itself. This change will create the `longestIncreasingSubsequence` from the `lengthsArray` and return that instead of `longestIncreasingLength`.