### PR TITLE
Add cycle creation utility and detection tests for Linked List (Fixes #583)

### DIFF
--- a/src/algorithms/linked-list/cycle/__tests__/cycle.test.js
+++ b/src/algorithms/linked-list/cycle/__tests__/cycle.test.js
@@ -1,0 +1,50 @@
+import LinkedList from '../../../../data-structures/linked-list/LinkedList';
+import createCycle from '../createCycle';
+import detectCycle from '../detectCycle';
+
+describe('Linked List Cycle Tests', () => {
+  let list;
+
+  beforeEach(() => {
+    list = new LinkedList();
+  });
+
+  test('detectCycle returns false on list with no cycle', () => {
+    list
+      .append(1)
+      .append(9)
+      .append(87)
+      .append(5)
+      .append(22);
+    expect(detectCycle(list)).toBe(false);
+  });
+
+  test('createCycle creates a cycle and detectCycle detects it', () => {
+    list
+      .append(1)
+      .append(9)
+      .append(87)
+      .append(5)
+      .append(22);
+    createCycle(list, 2); // Creates cycle linking tail to node at index 2 (value 87)
+    expect(detectCycle(list)).toBe(true);
+  });
+
+  test('createCycle with invalid position does not create cycle', () => {
+    list
+      .append(1)
+      .append(9)
+      .append(87);
+    createCycle(list, 10); // Invalid index, no cycle should be created
+    expect(detectCycle(list)).toBe(false);
+  });
+
+  test('createCycle with position -1 does not create cycle', () => {
+    list
+      .append(1)
+      .append(9)
+      .append(87);
+    createCycle(list, -1); // No cycle created
+    expect(detectCycle(list)).toBe(false);
+  });
+});

--- a/src/algorithms/linked-list/cycle/createCycle.js
+++ b/src/algorithms/linked-list/cycle/createCycle.js
@@ -1,0 +1,24 @@
+export default function createCycle(linkedList, position) {
+  if (!linkedList.head || position < 0) return;
+
+  let cycleNode = null;
+  let tail = linkedList.head;
+  let index = 0;
+
+  while (tail.next) {
+    if (index === position) {
+      cycleNode = tail;
+    }
+    tail = tail.next;
+    index += 1;
+  }
+
+  // For the last node
+  if (index === position) {
+    cycleNode = tail;
+  }
+
+  if (cycleNode) {
+    tail.next = cycleNode;
+  }
+}

--- a/src/algorithms/linked-list/cycle/detectCycle.js
+++ b/src/algorithms/linked-list/cycle/detectCycle.js
@@ -1,0 +1,15 @@
+export default function detectCycle(linkedList) {
+  let slow = linkedList.head;
+  let fast = linkedList.head;
+
+  while (fast && fast.next) {
+    slow = slow.next;
+    fast = fast.next.next;
+
+    if (slow === fast) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION

Description:
This pull request adds the ability to create a cycle in the linked list by linking the tail node to any node at a specified position. It includes:

A utility function createCycle(list, position) that links the last node to the node at the given position to form a cycle.

Unit tests to verify cycle creation and detection using the existing detectCycle function.

Tests cover normal cases, invalid positions, and no-cycle scenarios.

This addresses the feature request in issue #583 opened by @chrisVillanueva, enabling users to create and detect cycles within linked lists for more comprehensive linked list operations.

Please review the implementation and tests. Looking forward to your feedback!

