### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -32,4 +32,4 @@ jobs:
         run: npm run coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/CI.yml`
- Updated `codecov/codecov-action` from `v1` to `v5` in `.github/workflows/CI.yml`
- Updated `actions/setup-node` from `v1` to `v6` in `.github/workflows/CI.yml`
