### PR TITLE
fix comparator name in remove method

### DIFF
--- a/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
+++ b/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
@@ -110,7 +110,7 @@ export default class BinarySearchTreeNode extends BinaryTreeNode {
       // Find the next biggest value (minimum value in the right branch)
       // and replace current value node with that next biggest value.
       const nextBiggerNode = nodeToRemove.right.findMin();
-      if (!this.nodeComparator.equal(nextBiggerNode, nodeToRemove.right)) {
+      if (!this.nodeValueComparator.equal(nextBiggerNode, nodeToRemove.right)) {
         this.remove(nextBiggerNode.value);
         nodeToRemove.setValue(nextBiggerNode.value);
       } else {


### PR DESCRIPTION
hey, noticed a typo in the remove method. it was using `this.nodeComparator.equal()` but the class only has `this.nodeValueComparator`.

changed it to use the correct comparator. should fix the issue with removing nodes.

let me know if anything needs changing!

fixes #2102