### PR TITLE
fix(tree): preserve parent pointer in replaceChild

### DIFF
--- a/src/data-structures/tree/BinaryTreeNode.js
+++ b/src/data-structures/tree/BinaryTreeNode.js
@@ -167,11 +167,13 @@ export default class BinaryTreeNode {
 
     if (this.left && this.nodeComparator.equal(this.left, nodeToReplace)) {
       this.left = replacementNode;
+      this.left.parent = this;
       return true;
     }
 
     if (this.right && this.nodeComparator.equal(this.right, nodeToReplace)) {
       this.right = replacementNode;
+      this.right.parent = this;
       return true;
     }
 

--- a/src/data-structures/tree/__test__/BinaryTreeNode.test.js
+++ b/src/data-structures/tree/__test__/BinaryTreeNode.test.js
@@ -91,6 +91,7 @@ describe('BinaryTreeNode', () => {
 
     expect(rootNode.replaceChild(rootNode.right, rootNode.right.right)).toBe(true);
     expect(rootNode.right.value).toBe(5);
+    expect(rootNode.right.parent).toEqual(rootNode);
     expect(rootNode.right.right).toBeNull();
     expect(rootNode.traverseInOrder()).toEqual([1, 2, 5]);
 


### PR DESCRIPTION
## Summary
- set the replacement node's parent when `BinaryTreeNode.replaceChild()` swaps a child reference
- add a regression assertion covering the parent pointer after replacement

## Validation
- `npx eslint src/data-structures/tree/BinaryTreeNode.js src/data-structures/tree/__test__/BinaryTreeNode.test.js`
- `npx -y @babel/node --presets @babel/preset-env -e "const assert = require('assert'); const BinaryTreeNode = require('./src/data-structures/tree/BinaryTreeNode').default; const root = new BinaryTreeNode(2); const oldRight = new BinaryTreeNode(3); const replacement = new BinaryTreeNode(5); oldRight.setRight(replacement); root.setRight(oldRight); assert.strictEqual(root.replaceChild(root.right, root.right.right), true); assert.strictEqual(root.right, replacement); assert.strictEqual(root.right.parent, root); console.log('binary-tree-replacechild-parent-ok');"`

Closes #1102.