### PR TITLE
fix: correct broken permutations README image

### DIFF
--- a/src/algorithms/sets/permutations/README.md
+++ b/src/algorithms/sets/permutations/README.md
@@ -29,7 +29,7 @@ n * (n-1) * (n -2) * ... * 1 = n!
 When repetition is allowed we have permutations with repetitions.
 For example the the lock below: it could be `333`.
 
-![Permutation Lock](https://www.mathsisfun.com/combinatorics/images/combination-lock.jpg)
+![Permutation Lock](https://www.mathsisfun.com/combinatorics/images/permutation-lock.jpg)
 
 **Number of combinations**
 


### PR DESCRIPTION
## Summary
- fix the broken external image URL in src/algorithms/sets/permutations/README.md
- point the Permutation Lock image to the live permutation-lock.jpg asset instead of the 404ing combination-lock.jpg

## Validation
- Invoke-WebRequest -Uri 'https://www.mathsisfun.com/combinatorics/images/permutation-lock.jpg' -Method Head
- verified the response status is 200

Closes #2049