### PR TITLE
Add Traditional Chinese translations for data structures

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,9 +2,11 @@
 
 [![CI](https://github.com/trekhleb/javascript-algorithms/workflows/CI/badge.svg)](https://github.com/trekhleb/javascript-algorithms/actions?query=workflow%3ACI+branch%3Amaster)
 [![codecov](https://codecov.io/gh/trekhleb/javascript-algorithms/branch/master/graph/badge.svg)](https://codecov.io/gh/trekhleb/javascript-algorithms)
+![repo size](https://img.shields.io/github/repo-size/trekhleb/javascript-algorithms.svg)
 
-這個知識庫包含許多 JavaScript 的資料結構與演算法的基礎範例。
-每個演算法和資料結構都有其個別的文件，內有相關的解釋以及更多相關的文章或Youtube影片連結。
+這個知識庫包含許多以 JavaScript 為基礎的演算法與資料結構範例。
+
+每個演算法和資料結構都有其獨立的 README，內含相關說明及延伸閱讀連結（包含 YouTube 影片）。
 
 _Read this in other languages:_
 [_English_](https://github.com/trekhleb/javascript-algorithms/),
@@ -16,159 +18,262 @@ _Read this in other languages:_
 [_Español_](README.es-ES.md),
 [_Português_](README.pt-BR.md),
 [_Русский_](README.ru-RU.md),
-[_Türk_](README.tr-TR.md),
-[_Italiana_](README.it-IT.md),
+[_Türkçe_](README.tr-TR.md),
+[_Italiano_](README.it-IT.md),
 [_Bahasa Indonesia_](README.id-ID.md),
 [_Українська_](README.uk-UA.md),
 [_Arabic_](README.ar-AR.md),
 [_Tiếng Việt_](README.vi-VN.md),
 [_Deutsch_](README.de-DE.md),
-[_Uzbek_](README.uz-UZ.md)
+[_Uzbek_](README.uz-UZ.md),
 [_עברית_](README.he-IL.md)
 
 ## 資料結構
 
-資料結構是一個電腦用來組織和排序資料的特定方式，透過這樣的方式資料可以有效率地被讀取以及修改。更精確地說，一個資料結構是一個資料值的集合、彼此間的關係，函數或者運作可以應用於資料上。
+資料結構是一種在電腦中組織和儲存資料的特定方式，使得資料可以被有效率地存取和修改。更精確地說，資料結構是資料值的集合，表示資料之間的關係，以及可以應用於資料上的函數或操作。
 
-* [鏈結串列](src/data-structures/linked-list)
-* [貯列](src/data-structures/queue)
-* [堆疊](src/data-structures/stack)
-* [雜湊表](src/data-structures/hash-table)
-* [堆](src/data-structures/heap)
-* [優先貯列](src/data-structures/priority-queue)
-* [字典樹](src/data-structures/trie)
-* [樹](src/data-structures/tree)
-  * [二元搜尋樹](src/data-structures/tree/binary-search-tree)
-  * [AVL樹](src/data-structures/tree/avl-tree)
-  * [紅黑樹](src/data-structures/tree/red-black-tree)
-* [圖](src/data-structures/graph) (有向跟無向皆包含)
-* [互斥集](src/data-structures/disjoint-set)
+`B` - 初學者，`A` - 進階
+
+* `B` [鏈結串列](src/data-structures/linked-list/README.zh-TW.md)
+* `B` [雙向鏈結串列](src/data-structures/doubly-linked-list)
+* `B` [佇列](src/data-structures/queue/README.zh-TW.md)
+* `B` [堆疊](src/data-structures/stack/README.zh-TW.md)
+* `B` [雜湊表](src/data-structures/hash-table/README.zh-TW.md)
+* `B` [堆積](src/data-structures/heap/README.zh-TW.md) - 最大堆積與最小堆積
+* `B` [優先佇列](src/data-structures/priority-queue)
+* `A` [字典樹](src/data-structures/trie)
+* `A` [樹](src/data-structures/tree/README.zh-TW.md)
+  * `A` [二元搜尋樹](src/data-structures/tree/binary-search-tree)
+  * `A` [AVL 樹](src/data-structures/tree/avl-tree)
+  * `A` [紅黑樹](src/data-structures/tree/red-black-tree)
+  * `A` [線段樹](src/data-structures/tree/segment-tree) - 包含最小值/最大值/總和的範圍查詢範例
+  * `A` [樹狀數組](src/data-structures/tree/fenwick-tree)（二元索引樹）
+* `A` [圖](src/data-structures/graph)（有向圖與無向圖）
+* `A` [互斥集](src/data-structures/disjoint-set) - 聯集-查找資料結構或合併-查找集合
+* `A` [布隆過濾器](src/data-structures/bloom-filter)
+* `A` [LRU 快取](src/data-structures/lru-cache/) - 最近最少使用快取
 
 ## 演算法
 
-演算法是一個如何解決一類問題的非模糊規格。演算法是一個具有精確地定義了一系列運作的規則的集合
+演算法是解決一類問題的明確規範。演算法是一組精確定義操作序列的規則。
 
-### 演算法議題分類
+`B` - 初學者，`A` - 進階
 
-* **數學類**
-  * [階層](src/algorithms/math/factorial)
-  * [費伯納西數列](src/algorithms/math/fibonacci)
-  * [Primality Test](src/algorithms/math/primality-test) (排除法)
-  * [歐幾里得算法](src/algorithms/math/euclidean-algorithm) - 計算最大公因數 (GCD)
-  * [最小公倍數](src/algorithms/math/least-common-multiple) (LCM)
-  * [整數拆分](src/algorithms/math/integer-partition)
+### 演算法主題分類
+
+* **數學**
+  * `B` [位元運算](src/algorithms/math/bits) - 設定/取得/更新/清除位元、乘以/除以二、變負數等
+  * `B` [二進位浮點數](src/algorithms/math/binary-floating-point) - 浮點數的二進位表示法
+  * `B` [階乘](src/algorithms/math/factorial)
+  * `B` [費波那契數列](src/algorithms/math/fibonacci) - 經典版與封閉公式版
+  * `B` [質因數](src/algorithms/math/prime-factors) - 尋找質因數並使用 Hardy-Ramanujan 定理計算質因數個數
+  * `B` [質數檢測](src/algorithms/math/primality-test)（試除法）
+  * `B` [歐幾里得演算法](src/algorithms/math/euclidean-algorithm) - 計算最大公因數（GCD）
+  * `B` [最小公倍數](src/algorithms/math/least-common-multiple)（LCM）
+  * `B` [埃拉托斯特尼篩法](src/algorithms/math/sieve-of-eratosthenes) - 尋找指定範圍內的所有質數
+  * `B` [二的冪次判斷](src/algorithms/math/is-power-of-two) - 檢查數字是否為二的冪次（原生演算法與位元運算演算法）
+  * `B` [巴斯卡三角形](src/algorithms/math/pascal-triangle)
+  * `B` [複數](src/algorithms/math/complex-number) - 複數及其基本運算
+  * `B` [弧度與角度](src/algorithms/math/radian) - 弧度與角度的互相轉換
+  * `B` [快速冪](src/algorithms/math/fast-powering)
+  * `B` [霍納法則](src/algorithms/math/horner-method) - 多項式求值
+  * `B` [矩陣](src/algorithms/math/matrix) - 矩陣及基本矩陣運算（乘法、轉置等）
+  * `B` [歐幾里得距離](src/algorithms/math/euclidean-distance) - 兩點/向量/矩陣之間的距離
+  * `A` [整數拆分](src/algorithms/math/integer-partition)
+  * `A` [平方根](src/algorithms/math/square-root) - 牛頓法
+  * `A` [劉徽割圓術](src/algorithms/math/liu-hui) - 基於 N 邊形的近似圓周率計算
+  * `A` [離散傅立葉轉換](src/algorithms/math/fourier-transform) - 將時間訊號分解為組成它的各個頻率
 * **集合**
-  * [笛卡爾積](src/algorithms/sets/cartesian-product) - 多個集合的乘積
-  * [冪集合](src/algorithms/sets/power-set) - 所有集合的子集合
-  * [排列](src/algorithms/sets/permutations) (有/無重複)
-  * [组合](src/algorithms/sets/combinations) (有/無重複)
-  * [洗牌算法](src/algorithms/sets/fisher-yates) - 隨機置換一有限序列
-  * [最長共同子序列](src/algorithms/sets/longest-common-subsequence) (LCS)
-  * [最長遞增子序列](src/algorithms/sets/longest-increasing-subsequence)
-  * [Shortest Common Supersequence](src/algorithms/sets/shortest-common-supersequence) (SCS)
-  * [背包問題](src/algorithms/sets/knapsack-problem) - "0/1" and "Unbound" ones
-  * [最大子序列問題](src/algorithms/sets/maximum-subarray) - 暴力法以及動態編程的(Kadane's)版本
+  * `B` [笛卡爾積](src/algorithms/sets/cartesian-product) - 多個集合的乘積
+  * `B` [洗牌演算法](src/algorithms/sets/fisher-yates) - 隨機置換有限序列
+  * `A` [冪集合](src/algorithms/sets/power-set) - 集合的所有子集（位元運算、回溯法與遞推法）
+  * `A` [排列](src/algorithms/sets/permutations)（有/無重複）
+  * `A` [組合](src/algorithms/sets/combinations)（有/無重複）
+  * `A` [最長共同子序列](src/algorithms/sets/longest-common-subsequence)（LCS）
+  * `A` [最長遞增子序列](src/algorithms/sets/longest-increasing-subsequence)
+  * `A` [最短共同超序列](src/algorithms/sets/shortest-common-supersequence)（SCS）
+  * `A` [背包問題](src/algorithms/sets/knapsack-problem) - 「0/1」與「無限」版本
+  * `A` [最大子序列](src/algorithms/sets/maximum-subarray) - 暴力法與動態規劃（Kadane's）版本
+  * `A` [組合總和](src/algorithms/sets/combination-sum) - 找出所有構成特定總和的組合
 * **字串**
-  * [萊文斯坦距離](src/algorithms/string/levenshtein-distance) - 兩序列間的最小編輯距離
-  * [漢明距離](src/algorithms/string/hamming-distance) - number of positions at which the symbols are different
-  * [KMP 演算法](src/algorithms/string/knuth-morris-pratt) - 子字串搜尋
-  * [Rabin Karp 演算法](src/algorithms/string/rabin-karp) - 子字串搜尋
-  * [最長共通子序列](src/algorithms/string/longest-common-substring)
+  * `B` [漢明距離](src/algorithms/string/hamming-distance) - 符號不同的位置數
+  * `B` [迴文](src/algorithms/string/palindrome) - 檢查字串是否為迴文
+  * `A` [萊文斯坦距離](src/algorithms/string/levenshtein-distance) - 兩個序列之間的最小編輯距離
+  * `A` [KMP 演算法](src/algorithms/string/knuth-morris-pratt)（Knuth-Morris-Pratt）- 子字串搜尋（模式匹配）
+  * `A` [Z 演算法](src/algorithms/string/z-algorithm) - 子字串搜尋（模式匹配）
+  * `A` [Rabin-Karp 演算法](src/algorithms/string/rabin-karp) - 子字串搜尋
+  * `A` [最長共同子字串](src/algorithms/string/longest-common-substring)
+  * `A` [正規表達式匹配](src/algorithms/string/regular-expression-matching)
 * **搜尋**
-  * [二元搜尋](src/algorithms/search/binary-search)
+  * `B` [線性搜尋](src/algorithms/search/linear-search)
+  * `B` [跳躍搜尋](src/algorithms/search/jump-search)（或區塊搜尋）- 在已排序陣列中搜尋
+  * `B` [二元搜尋](src/algorithms/search/binary-search) - 在已排序陣列中搜尋
+  * `B` [內插搜尋](src/algorithms/search/interpolation-search) - 在均勻分佈的已排序陣列中搜尋
 * **排序**
-  * [氣泡排序](src/algorithms/sorting/bubble-sort)
-  * [選擇排序](src/algorithms/sorting/selection-sort)
-  * [插入排序](src/algorithms/sorting/insertion-sort)
-  * [堆排序](src/algorithms/sorting/heap-sort)
-  * [合併排序](src/algorithms/sorting/merge-sort)
-  * [快速排序](src/algorithms/sorting/quick-sort)
-  * [希爾排序](src/algorithms/sorting/shell-sort)
+  * `B` [氣泡排序](src/algorithms/sorting/bubble-sort)
+  * `B` [選擇排序](src/algorithms/sorting/selection-sort)
+  * `B` [插入排序](src/algorithms/sorting/insertion-sort)
+  * `B` [堆積排序](src/algorithms/sorting/heap-sort)
+  * `B` [合併排序](src/algorithms/sorting/merge-sort)
+  * `B` [快速排序](src/algorithms/sorting/quick-sort) - 原地（in-place）與非原地版本
+  * `B` [希爾排序](src/algorithms/sorting/shell-sort)
+  * `B` [計數排序](src/algorithms/sorting/counting-sort)
+  * `B` [基數排序](src/algorithms/sorting/radix-sort)
+  * `B` [桶排序](src/algorithms/sorting/bucket-sort)
+* **鏈結串列**
+  * `B` [正向走訪](src/algorithms/linked-list/traversal)
+  * `B` [反向走訪](src/algorithms/linked-list/reverse-traversal)
 * **樹**
-  * [深度優先搜尋](src/algorithms/tree/depth-first-search) (DFS)
-  * [廣度優先搜尋](src/algorithms/tree/breadth-first-search) (BFS)
+  * `B` [深度優先搜尋](src/algorithms/tree/depth-first-search)（DFS）
+  * `B` [廣度優先搜尋](src/algorithms/tree/breadth-first-search)（BFS）
 * **圖**
-  * [深度優先搜尋](src/algorithms/graph/depth-first-search) (DFS)
-  * [廣度優先搜尋](src/algorithms/graph/breadth-first-search) (BFS)
-  * [Dijkstra 演算法](src/algorithms/graph/dijkstra) - 找到所有圖頂點的最短路徑
-  * [Bellman-Ford 演算法](src/algorithms/graph/bellman-ford) - 找到所有圖頂點的最短路徑
-  * [Detect Cycle](src/algorithms/graph/detect-cycle) - for both directed and undirected graphs (DFS and Disjoint Set based versions)
-  * [Prim’s 演算法](src/algorithms/graph/prim) - finding Minimum Spanning Tree (MST) for weighted undirected graph
-  * [Kruskal’s 演算法](src/algorithms/graph/kruskal) - finding Minimum Spanning Tree (MST) for weighted undirected graph
-  * [拓撲排序](src/algorithms/graph/topological-sorting) - DFS method
-  * [關節點](src/algorithms/graph/articulation-points) - Tarjan's algorithm (DFS based)
-  * [橋](src/algorithms/graph/bridges) - DFS based algorithm
-  * [尤拉路徑及尤拉環](src/algorithms/graph/eulerian-path) - Fleury's algorithm - Visit every edge exactly once
-  * [漢彌爾頓環](src/algorithms/graph/hamiltonian-cycle) - Visit every vertex exactly once
-  * [強連通組件](src/algorithms/graph/strongly-connected-components) - Kosaraju's algorithm
-  * [旅行推銷員問題](src/algorithms/graph/travelling-salesman) - shortest possible route that visits each city and returns to the origin city
-  * [Floyd-Warshall algorithm](src/algorithms/graph/floyd-warshall) - 一次循环可以找出所有頂點之间的最短路徑
+  * `B` [深度優先搜尋](src/algorithms/graph/depth-first-search)（DFS）
+  * `B` [廣度優先搜尋](src/algorithms/graph/breadth-first-search)（BFS）
+  * `B` [Kruskal 演算法](src/algorithms/graph/kruskal) - 尋找加權無向圖的最小生成樹（MST）
+  * `A` [Dijkstra 演算法](src/algorithms/graph/dijkstra) - 從單一頂點找到所有圖頂點的最短路徑
+  * `A` [Bellman-Ford 演算法](src/algorithms/graph/bellman-ford) - 從單一頂點找到所有圖頂點的最短路徑
+  * `A` [Floyd-Warshall 演算法](src/algorithms/graph/floyd-warshall) - 找到所有頂點對之間的最短路徑
+  * `A` [偵測環](src/algorithms/graph/detect-cycle) - 針對有向圖與無向圖（基於 DFS 和互斥集的版本）
+  * `A` [Prim 演算法](src/algorithms/graph/prim) - 尋找加權無向圖的最小生成樹（MST）
+  * `A` [拓撲排序](src/algorithms/graph/topological-sorting) - DFS 方法
+  * `A` [關節點](src/algorithms/graph/articulation-points) - Tarjan 演算法（基於 DFS）
+  * `A` [橋](src/algorithms/graph/bridges) - 基於 DFS 的演算法
+  * `A` [尤拉路徑與尤拉迴路](src/algorithms/graph/eulerian-path) - Fleury 演算法 - 恰好經過每條邊一次
+  * `A` [漢彌爾頓迴路](src/algorithms/graph/hamiltonian-cycle) - 恰好造訪每個頂點一次
+  * `A` [強連通分量](src/algorithms/graph/strongly-connected-components) - Kosaraju 演算法
+  * `A` [旅行推銷員問題](src/algorithms/graph/travelling-salesman) - 盡可能以最短路線造訪每座城市並返回出發城市
+* **密碼學**
+  * `B` [多項式雜湊](src/algorithms/cryptography/polynomial-hash) - 基於多項式的滾動雜湊函數
+  * `B` [柵欄密碼](src/algorithms/cryptography/rail-fence-cipher) - 一種用於編碼訊息的轉置密碼演算法
+  * `B` [凱薩密碼](src/algorithms/cryptography/caesar-cipher) - 簡單替換密碼
+  * `B` [希爾密碼](src/algorithms/cryptography/hill-cipher) - 基於線性代數的替換密碼
+* **機器學習**
+  * `B` [NanoNeuron](https://github.com/trekhleb/nano-neuron) - 7 個簡單的 JS 函數，說明機器如何實際學習（前向/反向傳播）
+  * `B` [k-近鄰演算法](src/algorithms/ml/knn) - k-最近鄰分類演算法
+  * `B` [k-平均演算法](src/algorithms/ml/k-means) - k-平均分群演算法
+* **影像處理**
+  * `B` [接縫裁剪](src/algorithms/image-processing/seam-carving) - 內容感知圖片縮放演算法
+* **統計**
+  * `B` [加權隨機](src/algorithms/statistics/weighted-random) - 根據項目的權重從列表中選取隨機項目
+* **演化演算法**
+  * `A` [遺傳演算法](https://github.com/trekhleb/self-parking-car-evolution) - 遺傳演算法如何應用於自動停車訓練的範例
 * **未分類**
-  * [河內塔](src/algorithms/uncategorized/hanoi-tower)
-  * [N-皇后問題](src/algorithms/uncategorized/n-queens)
-  * [騎士走棋盤](src/algorithms/uncategorized/knight-tour)
+  * `B` [河內塔](src/algorithms/uncategorized/hanoi-tower)
+  * `B` [方陣旋轉](src/algorithms/uncategorized/square-matrix-rotation) - 原地演算法
+  * `B` [跳躍遊戲](src/algorithms/uncategorized/jump-game) - 回溯法、動態規劃（由上而下與由下而上）與貪婪法範例
+  * `B` [唯一路徑](src/algorithms/uncategorized/unique-paths) - 回溯法、動態規劃與巴斯卡三角形範例
+  * `B` [雨水收集](src/algorithms/uncategorized/rain-terraces) - 接雨水問題（動態規劃與暴力法版本）
+  * `B` [遞迴階梯](src/algorithms/uncategorized/recursive-staircase) - 計算到達頂層共有多少種方法（4 種解法）
+  * `B` [最佳股票買賣時機](src/algorithms/uncategorized/best-time-to-buy-sell-stocks) - 分治法與一次遍歷範例
+  * `B` [有效括號](src/algorithms/stack/valid-parentheses) - 檢查字串是否包含有效括號（使用堆疊）
+  * `A` [N 皇后問題](src/algorithms/uncategorized/n-queens)
+  * `A` [騎士巡邏](src/algorithms/uncategorized/knight-tour)
 
 ### 演算法範型
 
-演算法的範型是一個泛用方法或設計一類底層演算法的方式。它是一個比演算法的概念更高階的抽象化，就像是演算法是比電腦程式更高階的抽象化。
+演算法範型是一種設計一類底層演算法的泛用方法或途徑。它是比演算法更高階的抽象化，就如同演算法是比電腦程式更高階的抽象化一樣。
 
-* **暴力法** - 尋遍所有的可能解然後選取最好的解
-  * [最大子序列](src/algorithms/sets/maximum-subarray)
-  * [旅行推銷員問題](src/algorithms/graph/travelling-salesman) - shortest possible route that visits each city and returns to the origin city
-* **貪婪法** - choose the best option at the current time, without any consideration for the future
-  * [未定背包問題](src/algorithms/sets/knapsack-problem)
-  * [Dijkstra 演算法](src/algorithms/graph/dijkstra) - 找到所有圖頂點的最短路徑
-  * [Prim’s 演算法](src/algorithms/graph/prim) - finding Minimum Spanning Tree (MST) for weighted undirected graph
-  * [Kruskal’s 演算法](src/algorithms/graph/kruskal) - finding Minimum Spanning Tree (MST) for weighted undirected graph
-* **分治法** - divide the problem into smaller parts and then solve those parts
-  * [二元搜尋](src/algorithms/search/binary-search)
-  * [河內塔](src/algorithms/uncategorized/hanoi-tower)
-  * [歐幾里得演算法](src/algorithms/math/euclidean-algorithm) - calculate the Greatest Common Divisor (GCD)
-  * [排列](src/algorithms/sets/permutations) (有/無重複)
-  * [组合](src/algorithms/sets/combinations) (有/無重複)
-  * [合併排序](src/algorithms/sorting/merge-sort)
-  * [快速排序](src/algorithms/sorting/quick-sort)
-  * [樹深度優先搜尋](src/algorithms/tree/depth-first-search) (DFS)
-  * [圖深度優先搜尋](src/algorithms/graph/depth-first-search) (DFS)
-* **動態編程** - build up to a solution using previously found sub-solutions
-  * [費伯納西數列](src/algorithms/math/fibonacci)
-  * [萊溫斯坦距離](src/algorithms/string/levenshtein-distance) - minimum edit distance between two sequences
-  * [最長共同子序列](src/algorithms/sets/longest-common-subsequence) (LCS)
-  * [最長共同子字串](src/algorithms/string/longest-common-substring)
-  * [最長遞增子序列](src/algorithms/sets/longest-increasing-subsequence)
-  * [最短共同子序列](src/algorithms/sets/shortest-common-supersequence)
-  * [0/1背包問題](src/algorithms/sets/knapsack-problem)
-  * [整數拆分](src/algorithms/math/integer-partition)
-  * [最大子序列](src/algorithms/sets/maximum-subarray)
-  * [Bellman-Ford 演算法](src/algorithms/graph/bellman-ford) - finding shortest path to all graph vertices
-* **回溯法** - 用類似暴力法來嘗試產生所有可能解，但每次只在能滿足所有測試條件，且只有繼續產生子序列方案來產生的解決方案。否則回溯並尋找不同路徑的解決方案。
-  * [漢彌爾頓迴路](src/algorithms/graph/hamiltonian-cycle) - Visit every vertex exactly once
-  * [N-皇后問題](src/algorithms/uncategorized/n-queens)
-  * [騎士走棋盤](src/algorithms/uncategorized/knight-tour)
-* **Branch & Bound**
+* **暴力法** - 尋遍所有可能解，然後選取最佳解
+  * `B` [線性搜尋](src/algorithms/search/linear-search)
+  * `B` [雨水收集](src/algorithms/uncategorized/rain-terraces) - 接雨水問題
+  * `B` [遞迴階梯](src/algorithms/uncategorized/recursive-staircase) - 計算到達頂層的方法數
+  * `A` [最大子序列](src/algorithms/sets/maximum-subarray)
+  * `A` [旅行推銷員問題](src/algorithms/graph/travelling-salesman) - 盡可能以最短路線造訪每座城市並返回出發城市
+  * `A` [離散傅立葉轉換](src/algorithms/math/fourier-transform) - 將時間訊號分解為組成它的各個頻率
+* **貪婪法** - 在當前選擇最佳選項，不考慮未來的情況
+  * `B` [跳躍遊戲](src/algorithms/uncategorized/jump-game)
+  * `A` [無限背包問題](src/algorithms/sets/knapsack-problem)
+  * `A` [Dijkstra 演算法](src/algorithms/graph/dijkstra) - 找到所有圖頂點的最短路徑
+  * `A` [Prim 演算法](src/algorithms/graph/prim) - 尋找加權無向圖的最小生成樹（MST）
+  * `A` [Kruskal 演算法](src/algorithms/graph/kruskal) - 尋找加權無向圖的最小生成樹（MST）
+* **分治法** - 將問題分成較小的部分，然後解決這些部分
+  * `B` [二元搜尋](src/algorithms/search/binary-search)
+  * `B` [河內塔](src/algorithms/uncategorized/hanoi-tower)
+  * `B` [巴斯卡三角形](src/algorithms/math/pascal-triangle)
+  * `B` [歐幾里得演算法](src/algorithms/math/euclidean-algorithm) - 計算最大公因數（GCD）
+  * `B` [合併排序](src/algorithms/sorting/merge-sort)
+  * `B` [快速排序](src/algorithms/sorting/quick-sort)
+  * `B` [樹深度優先搜尋](src/algorithms/tree/depth-first-search)（DFS）
+  * `B` [圖深度優先搜尋](src/algorithms/graph/depth-first-search)（DFS）
+  * `B` [矩陣](src/algorithms/math/matrix) - 產生與走訪不同形狀的矩陣
+  * `B` [跳躍遊戲](src/algorithms/uncategorized/jump-game)
+  * `B` [快速冪](src/algorithms/math/fast-powering)
+  * `B` [最佳股票買賣時機](src/algorithms/uncategorized/best-time-to-buy-sell-stocks) - 分治法與一次遍歷範例
+  * `A` [排列](src/algorithms/sets/permutations)（有/無重複）
+  * `A` [組合](src/algorithms/sets/combinations)（有/無重複）
+  * `A` [最大子序列](src/algorithms/sets/maximum-subarray)
+* **動態規劃** - 利用先前找到的子問題解來建構解答
+  * `B` [費波那契數列](src/algorithms/math/fibonacci)
+  * `B` [跳躍遊戲](src/algorithms/uncategorized/jump-game)
+  * `B` [唯一路徑](src/algorithms/uncategorized/unique-paths)
+  * `B` [雨水收集](src/algorithms/uncategorized/rain-terraces) - 接雨水問題
+  * `B` [遞迴階梯](src/algorithms/uncategorized/recursive-staircase) - 計算到達頂層的方法數
+  * `B` [接縫裁剪](src/algorithms/image-processing/seam-carving) - 內容感知圖片縮放演算法
+  * `A` [萊文斯坦距離](src/algorithms/string/levenshtein-distance) - 兩個序列之間的最小編輯距離
+  * `A` [最長共同子序列](src/algorithms/sets/longest-common-subsequence)（LCS）
+  * `A` [最長共同子字串](src/algorithms/string/longest-common-substring)
+  * `A` [最長遞增子序列](src/algorithms/sets/longest-increasing-subsequence)
+  * `A` [最短共同超序列](src/algorithms/sets/shortest-common-supersequence)
+  * `A` [0/1 背包問題](src/algorithms/sets/knapsack-problem)
+  * `A` [整數拆分](src/algorithms/math/integer-partition)
+  * `A` [最大子序列](src/algorithms/sets/maximum-subarray)
+  * `A` [Bellman-Ford 演算法](src/algorithms/graph/bellman-ford) - 找到所有圖頂點的最短路徑
+  * `A` [Floyd-Warshall 演算法](src/algorithms/graph/floyd-warshall) - 找到所有頂點對之間的最短路徑
+  * `A` [正規表達式匹配](src/algorithms/string/regular-expression-matching)
+* **回溯法** - 與暴力法類似，嘗試產生所有可能的解，但每次產生下一個解時，會先測試是否滿足所有條件，只有滿足條件才繼續產生後續的解。否則回溯並嘗試其他路徑。通常會使用狀態空間的 DFS 走訪。
+  * `B` [跳躍遊戲](src/algorithms/uncategorized/jump-game)
+  * `B` [唯一路徑](src/algorithms/uncategorized/unique-paths)
+  * `B` [冪集合](src/algorithms/sets/power-set) - 集合的所有子集
+  * `A` [漢彌爾頓迴路](src/algorithms/graph/hamiltonian-cycle) - 恰好造訪每個頂點一次
+  * `A` [N 皇后問題](src/algorithms/uncategorized/n-queens)
+  * `A` [騎士巡邏](src/algorithms/uncategorized/knight-tour)
+  * `A` [組合總和](src/algorithms/sets/combination-sum) - 找出所有構成特定總和的組合
+* **分支定界法** - 記住回溯搜尋過程中每個階段找到的最低成本解，並以目前已找到的最低成本作為下界，捨棄成本高於此下界的部分解。通常結合狀態空間樹的 BFS 與 DFS 走訪來使用。
 
 ## 如何使用本知識庫
 
-**安裝所有必須套件**
+**安裝所有必要套件**
 
 ```
 npm install
 ```
 
+**執行 ESLint**
+
+你可以執行它來檢查程式碼品質。
+
+```
+npm run lint
+```
+
 **執行所有測試**
+
 ```
 npm test
 ```
 
-**以名稱執行該測試**
+**依名稱執行測試**
+
 ```
 npm test -- 'LinkedList'
 ```
+
+**疑難排解**
+
+如果 lint 或測試執行失敗，可以嘗試刪除 `node_modules` 資料夾並重新安裝 npm 套件：
+
+```
+rm -rf ./node_modules
+npm i
+```
+
+另外，請確認你使用的是正確的 Node 版本（`>=16`）。如果你使用 [nvm](https://github.com/nvm-sh/nvm) 來管理 Node 版本，可以在專案根目錄執行 `nvm use`，它會自動使用正確的版本。
+
 **練習場**
 
-你可以透過在`./src/playground/playground.js`裡面的檔案練習資料結構以及演算法，並且撰寫在`./src/playground/__test__/playground.test.js`裡面的測試程式。
+你可以在 `./src/playground/playground.js` 檔案中練習資料結構與演算法，並在 `./src/playground/__test__/playground.test.js` 中撰寫測試程式。
 
-接著直接執行下列的指令來測試你練習的 code 是否如預期運作：
+接著執行下列指令來測試你的練習程式碼是否如預期運作：
 
 ```
 npm test -- 'playground'
@@ -176,54 +281,58 @@ npm test -- 'playground'
 
 ## 有用的資訊
 
-### 參考
+### 參考資料
 
-[▶ Data Structures and Algorithms on YouTube](https://www.youtube.com/playlist?list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8)
+- [▶ YouTube 上的資料結構與演算法](https://www.youtube.com/playlist?list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8)
+- [✍🏻 資料結構草圖](https://okso.app/showcase/data-structures)
 
-### 大 O 標記
+### Big O 標記法
 
-特別用大 O 標記演算法增長度的排序。
+*Big O 標記法*用於根據輸入資料規模的增長，來分類演算法的執行時間或空間需求的增長趨勢。在下方圖表中，你可以找到以 Big O 標記法表示的最常見演算法增長階數。
 
-![Big O 表](./assets/big-o-graph.png)
+![Big O 圖表](./assets/big-o-graph.png)
 
-資料來源: [Big O Cheat Sheet](http://bigocheatsheet.com/).
+資料來源：[Big O Cheat Sheet](http://bigocheatsheet.com/)。
 
-下列列出幾個常用的 Big O 標記以及其不同大小資料量輸入後的運算效能比較。
+以下列出幾個常用的 Big O 標記法，以及其在不同資料量輸入下的運算效能比較。
 
-| Big O 標記     | 10個資料量需花費的時間       | 100個資料量需花費的時間       | 1000個資料量需花費的時間        |
-| -------------- | ---------------------------- | ----------------------------- | ------------------------------- |
-| **O(1)**       | 1                            | 1                             | 1                               |
-| **O(log N)**   | 3                            | 6                             | 9                               |
-| **O(N)**       | 10                           | 100                           | 1000                            |
-| **O(N log N)** | 30                           | 600                           | 9000                            |
-| **O(N^2)**     | 100                          | 10000                         | 1000000                         |
-| **O(2^N)**     | 1024                         | 1.26e+29                      | 1.07e+301                       |
-| **O(N!)**      | 3628800                      | 9.3e+157                      | 4.02e+2567                      |
+| Big O 標記法   | 類型        | 10 個元素的計算量 | 100 個元素的計算量 | 1000 個元素的計算量 |
+| -------------- | ----------- | ----------------: | -----------------: | ------------------: |
+| **O(1)**       | 常數        | 1                 | 1                  | 1                   |
+| **O(log N)**   | 對數        | 3                 | 6                  | 9                   |
+| **O(N)**       | 線性        | 10                | 100                | 1000                |
+| **O(N log N)** | n log(n)    | 30                | 600                | 9000                |
+| **O(N^2)**     | 平方        | 100               | 10000              | 1000000             |
+| **O(2^N)**     | 指數        | 1024              | 1.26e+29           | 1.07e+301           |
+| **O(N!)**      | 階乘        | 3628800           | 9.3e+157           | 4.02e+2567          |
 
-### 資料結構運作複雜度
+### 資料結構操作複雜度
 
-| 資料結構                | 存取      | 搜尋      | 插入      | 刪除      |
-| ----------------------- | :-------: | :-------: | :-------: | :-------: |
-| **陣列**                | 1         | n         | n         | n         |
-| **堆疊**                | n         | n         | 1         | 1         |
-| **貯列**                | n         | n         | 1         | 1         |
-| **鏈結串列**            | n         | n         | 1         | 1         |
-| **雜湊表**              | -         | n         | n         | n         |
-| **二元搜尋樹**          | n         | n         | n         | n         |
-| **B-Tree**              | log(n)    | log(n)    | log(n)    | log(n)    |
-| **紅黑樹**              | log(n)    | log(n)    | log(n)    | log(n)    |
-| **AVL Tree**            | log(n)    | log(n)    | log(n)    | log(n)    |
+| 資料結構                | 存取      | 搜尋      | 插入      | 刪除      | 備註      |
+| ----------------------- | :-------: | :-------: | :-------: | :-------: | :-------- |
+| **陣列**                | 1         | n         | n         | n         |           |
+| **堆疊**                | n         | n         | 1         | 1         |           |
+| **佇列**                | n         | n         | 1         | 1         |           |
+| **鏈結串列**            | n         | n         | 1         | n         |           |
+| **雜湊表**              | -         | n         | n         | n         | 在完美雜湊函數的情況下，複雜度為 O(1) |
+| **二元搜尋樹**          | n         | n         | n         | n         | 在平衡樹的情況下，複雜度為 O(log(n)) |
+| **B 樹**                | log(n)    | log(n)    | log(n)    | log(n)    |           |
+| **紅黑樹**              | log(n)    | log(n)    | log(n)    | log(n)    |           |
+| **AVL 樹**              | log(n)    | log(n)    | log(n)    | log(n)    |           |
+| **布隆過濾器**          | -         | 1         | 1         | -         | 搜尋時可能產生偽陽性 |
 
 ### 陣列排序演算法複雜度
 
-| 名稱                   | 最佳      | 平均      | 最差          | 記憶體    | 穩定      |
-| ---------------------- | :-------: | :-------: | :-----------: | :-------: | :-------: |
-| **氣泡排序**           | n         | n^2       | n^2           | 1         | Yes       |
-| **插入排序**           | n         | n^2       | n^2           | 1         | Yes       |
-| **選擇排序**           | n^2       | n^2       | n^2           | 1         | No        |
-| **Heap 排序**          | n log(n)  | n log(n)  | n log(n)      | 1         | No        |
-| **合併排序**           | n log(n)  | n log(n)  | n log(n)      | n         | Yes       |
-| **快速排序**           | n log(n)  | n log(n)  | n^2           | log(n)    | No        |
-| **希爾排序**           | n log(n)  | 由gap sequence決定   | n (log(n))^2  | 1         | No        |
+| 名稱                   | 最佳            | 平均                | 最差                | 記憶體    | 穩定      | 備註      |
+| ---------------------- | :-------------: | :-----------------: | :-----------------: | :-------: | :-------: | :-------- |
+| **氣泡排序**           | n               | n<sup>2</sup>       | n<sup>2</sup>       | 1         | Yes       |           |
+| **插入排序**           | n               | n<sup>2</sup>       | n<sup>2</sup>       | 1         | Yes       |           |
+| **選擇排序**           | n<sup>2</sup>   | n<sup>2</sup>       | n<sup>2</sup>       | 1         | No        |           |
+| **堆積排序**           | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | 1         | No        |           |
+| **合併排序**           | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | n         | Yes       |           |
+| **快速排序**           | n&nbsp;log(n)   | n&nbsp;log(n)       | n<sup>2</sup>       | log(n)    | No        | 快速排序通常以原地方式進行，使用 O(log(n)) 的堆疊空間 |
+| **希爾排序**           | n&nbsp;log(n)   | 取決於間隔序列      | n&nbsp;(log(n))<sup>2</sup> | 1  | No        |           |
+| **計數排序**           | n + r           | n + r               | n + r               | n + r     | Yes       | r - 陣列中最大的數 |
+| **基數排序**           | n * k           | n * k               | n * k               | n + k     | Yes       | k - 最長鍵值的長度 |
 
-> ℹ️ A few more [projects](https://trekhleb.dev/projects/) and [articles](https://trekhleb.dev/blog/) about JavaScript and algorithms on [trekhleb.dev](https://trekhleb.dev)
+> ℹ️ 更多關於 JavaScript 和演算法的[專案](https://trekhleb.dev/projects/)與[文章](https://trekhleb.dev/blog/)，請參考 [trekhleb.dev](https://trekhleb.dev)

--- a/src/data-structures/hash-table/README.md
+++ b/src/data-structures/hash-table/README.md
@@ -7,7 +7,8 @@ _Read this in other languages:_
 [_Français_](README.fr-FR.md),
 [_Português_](README.pt-BR.md),
 [_한국어_](README.ko-KR.md),
-[_Українська_](README.uk-UA.md)
+[_Українська_](README.uk-UA.md),
+[_繁體中文_](README.zh-TW.md)
 
 In computing, a **hash table** (hash map) is a data
 structure which implements an _associative array_

--- a/src/data-structures/hash-table/README.zh-TW.md
+++ b/src/data-structures/hash-table/README.zh-TW.md
@@ -1,0 +1,28 @@
+# 雜湊表
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Русский_](README.ru-RU.md),
+[_日本語_](README.ja-JP.md),
+[_Français_](README.fr-FR.md),
+[_Português_](README.pt-BR.md),
+[_한국어_](README.ko-KR.md),
+[_Українська_](README.uk-UA.md)
+
+在電腦科學中，**雜湊表**（雜湊對映）是一種實作*關聯式陣列*抽象資料型別的資料結構，它可以將*鍵對映到值*。雜湊表使用*雜湊函數*來計算一個索引值，指向一個桶（bucket）或槽（slot）的陣列，從中可以找到所需的值。
+
+理想情況下，雜湊函數會將每個鍵分配到唯一的桶中，但大多數雜湊表的設計採用不完美的雜湊函數，這可能會導致雜湊碰撞——即雜湊函數為多個不同的鍵產生相同的索引值。這類碰撞必須以某種方式處理。
+
+![Hash Table](./images/hash-table.jpeg)
+
+透過分離鏈結法解決雜湊碰撞
+
+![Hash Collision](./images/collision-resolution.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/哈希表)
+- [YouTube](https://www.youtube.com/watch?v=shs0KM3wKv8&index=4&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8)

--- a/src/data-structures/heap/README.md
+++ b/src/data-structures/heap/README.md
@@ -8,7 +8,8 @@ _Read this in other languages:_
 [_Português_](README.pt-BR.md),
 [_Türkçe_](README.tr-TR.md),
 [_한국어_](README.ko-KR.md),
-[_Українська_](README.uk-UA.md)
+[_Українська_](README.uk-UA.md),
+[_繁體中文_](README.zh-TW.md)
 
 
 In computer science, a **heap** is a specialized tree-based

--- a/src/data-structures/heap/README.zh-TW.md
+++ b/src/data-structures/heap/README.zh-TW.md
@@ -1,0 +1,63 @@
+# 堆積（資料結構）
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Русский_](README.ru-RU.md),
+[_日本語_](README.ja-JP.md),
+[_Français_](README.fr-FR.md),
+[_Português_](README.pt-BR.md),
+[_Türkçe_](README.tr-TR.md),
+[_한국어_](README.ko-KR.md),
+[_Українська_](README.uk-UA.md)
+
+在電腦科學中，**堆積**是一種特殊的樹狀資料結構，滿足以下描述的堆積性質。
+
+在*最小堆積*中，若 `P` 是 `C` 的父節點，則 `P` 的鍵值（數值）小於或等於 `C` 的鍵值。
+
+![MinHeap](./images/min-heap.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+在*最大堆積*中，`P` 的鍵值大於或等於 `C` 的鍵值。
+
+![MaxHeap](./images/max-heap.jpeg)
+
+![Array Representation](./images/array-representation.jpeg)
+
+堆積中沒有父節點的最頂端節點稱為根節點。
+
+## 時間複雜度
+
+以下是各種堆積資料結構的時間複雜度。函數名稱假設為最大堆積。
+
+| 操作       | find-max   | delete-max | insert     | increase-key | meld       |
+| ---------- | ---------- | ---------- | ---------- | ------------ | ---------- |
+| [二元堆積](https://en.wikipedia.org/wiki/Binary_heap) | `Θ(1)` | `Θ(log n)` | `O(log n)` | `O(log n)` | `Θ(n)` |
+| [左偏樹](https://en.wikipedia.org/wiki/Leftist_tree) | `Θ(1)` | `Θ(log n)` | `Θ(log n)` | `O(log n)` | `Θ(log n)` |
+| [二項式堆積](https://en.wikipedia.org/wiki/Binomial_heap) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `O(log n)` | `O(log n)` |
+| [費波那契堆積](https://en.wikipedia.org/wiki/Fibonacci_heap) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `Θ(1)` | `Θ(1)` |
+| [配對堆積](https://en.wikipedia.org/wiki/Pairing_heap) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `o(log n)` | `Θ(1)` |
+| [Brodal 佇列](https://en.wikipedia.org/wiki/Brodal_queue) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `Θ(1)` | `Θ(1)` |
+| [Rank-pairing 堆積](https://en.wikipedia.org/w/index.php?title=Rank-pairing_heap&action=edit&redlink=1) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `Θ(1)` | `Θ(1)` |
+| [嚴格費波那契堆積](https://en.wikipedia.org/wiki/Fibonacci_heap) | `Θ(1)` | `Θ(log n)` | `Θ(1)` | `Θ(1)` | `Θ(1)` |
+| [2-3 堆積](https://en.wikipedia.org/wiki/2%E2%80%933_heap) | `O(log n)` | `O(log n)` | `O(log n)` | `Θ(1)` | `?` |
+
+其中：
+- **find-max（或 find-min）**：分別找到最大堆積中的最大項目或最小堆積中的最小項目（又稱 *peek*）
+- **delete-max（或 delete-min）**：分別移除最大堆積（或最小堆積）的根節點
+- **insert**：將新的鍵值加入堆積中（又稱 *push*）
+- **increase-key 或 decrease-key**：分別更新最大堆積或最小堆積中的鍵值
+- **meld**：將兩個堆積合併成一個新的有效堆積，包含兩者的所有元素，並銷毀原來的堆積
+
+> 在本知識庫中，[MaxHeap.js](./MaxHeap.js) 和 [MinHeap.js](./MinHeap.js) 是**二元堆積**的範例。
+
+## 實作
+
+- [MaxHeap.js](./MaxHeap.js) 和 [MinHeap.js](./MinHeap.js)
+- [MaxHeapAdhoc.js](./MaxHeapAdhoc.js) 和 [MinHeapAdhoc.js](./MinHeapAdhoc.js) - MinHeap/MaxHeap 資料結構的極簡（ad hoc）版本，不依賴外部相依套件，可在面試中輕鬆複製貼上使用（因為 JavaScript 中缺少許多資料結構）。
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/堆_(資料結構))
+- [YouTube](https://www.youtube.com/watch?v=t0Cq6tVNRBA&index=5&t=0s&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8)

--- a/src/data-structures/linked-list/README.md
+++ b/src/data-structures/linked-list/README.md
@@ -8,7 +8,8 @@ _Read this in other languages:_
 [_한국어_](README.ko-KR.md),
 [_Español_](README.es-ES.md),
 [_Türkçe_](README.tr-TR.md),
-[_Українська_](README.uk-UA.md)
+[_Українська_](README.uk-UA.md),
+[_繁體中文_](README.zh-TW.md)
 
 In computer science, a **linked list** is a linear collection
 of data elements, in which linear order is not given by

--- a/src/data-structures/linked-list/README.zh-TW.md
+++ b/src/data-structures/linked-list/README.zh-TW.md
@@ -1,0 +1,156 @@
+# 鏈結串列
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Русский_](README.ru-RU.md),
+[_日本語_](README.ja-JP.md),
+[_Português_](README.pt-BR.md),
+[_한국어_](README.ko-KR.md),
+[_Español_](README.es-ES.md),
+[_Türkçe_](README.tr-TR.md),
+[_Українська_](README.uk-UA.md)
+
+在電腦科學中，**鏈結串列**是一種資料元素的線性集合，其線性順序不是由元素在記憶體中的物理位置決定的。每個元素指向下一個元素。鏈結串列是由一組節點組成的資料結構，這些節點共同表示一個序列。在最簡單的形式下，每個節點由資料和一個指向序列中下一個節點的參考（換句話說，就是一個連結）組成。這種結構允許在走訪過程中，從序列的任何位置有效率地插入或移除元素。更複雜的變體會增加額外的連結，允許從任意元素參考進行有效率的插入或移除。鏈結串列的缺點是存取時間為線性的（且難以進行管線化處理）。較快速的存取方式，如隨機存取，是不可行的。與鏈結串列相比，陣列擁有更好的快取局部性。
+
+![Linked List](./images/linked-list.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+## 基本操作的虛擬碼
+
+### 插入
+
+```text
+Add(value)
+  Pre: value 是要新增到串列的值
+  Post: value 已被放置在串列的尾端
+  n ← node(value)
+  if head = ø
+    head ← n
+    tail ← n
+  else
+    tail.next ← n
+    tail ← n
+  end if
+end Add
+```
+
+```text
+Prepend(value)
+ Pre: value 是要新增到串列的值
+ Post: value 已被放置在串列的頭部
+ n ← node(value)
+ n.next ← head
+ head ← n
+ if tail = ø
+   tail ← n
+ end
+end Prepend
+```
+
+### 搜尋
+
+```text
+Contains(head, value)
+  Pre: head 是串列中的頭部節點
+       value 是要搜尋的值
+  Post: 如果項目在鏈結串列中則回傳 true；否則回傳 false
+  n ← head
+  while n != ø and n.value != value
+    n ← n.next
+  end while
+  if n = ø
+    return false
+  end if
+  return true
+end Contains
+```
+
+### 刪除
+
+```text
+Remove(head, value)
+  Pre: head 是串列中的頭部節點
+       value 是要從串列中移除的值
+  Post: 如果 value 從串列中移除則回傳 true，否則回傳 false
+  if head = ø
+    return false
+  end if
+  n ← head
+  if n.value = value
+    if head = tail
+      head ← ø
+      tail ← ø
+    else
+      head ← head.next
+    end if
+    return true
+  end if
+  while n.next != ø and n.next.value != value
+    n ← n.next
+  end while
+  if n.next != ø
+    if n.next = tail
+      tail ← n
+      tail.next = null
+    else
+      n.next ← n.next.next
+    end if
+    return true
+  end if
+  return false
+end Remove
+```
+
+### 走訪
+
+```text
+Traverse(head)
+  Pre: head 是串列中的頭部節點
+  Post: 串列中的項目已被走訪
+  n ← head
+  while n != ø
+    yield n.value
+    n ← n.next
+  end while
+end Traverse
+```
+
+### 反向走訪
+
+```text
+ReverseTraversal(head, tail)
+  Pre: head 和 tail 屬於同一個串列
+  Post: 串列中的項目已被反向走訪
+  if tail != ø
+    curr ← tail
+    while curr != head
+      prev ← head
+      while prev.next != curr
+        prev ← prev.next
+      end while
+      yield curr.value
+      curr ← prev
+    end while
+   yield curr.value
+  end if
+end ReverseTraversal
+```
+
+## 複雜度
+
+### 時間複雜度
+
+| 存取      | 搜尋      | 插入      | 刪除      |
+| :-------: | :-------: | :-------: | :-------: |
+| O(n)      | O(n)      | O(1)      | O(n)      |
+
+### 空間複雜度
+
+O(n)
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/链表)
+- [YouTube](https://www.youtube.com/watch?v=njTh_OwMljA&index=2&t=1s&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8)

--- a/src/data-structures/queue/README.md
+++ b/src/data-structures/queue/README.md
@@ -7,7 +7,8 @@ _Read this in other languages:_
 [_Français_](README.fr-FR.md),
 [_Português_](README.pt-BR.md),
 [_한국어_](README.ko-KR.md),
-[_Українська_](README.uk-UA.md)
+[_Українська_](README.uk-UA.md),
+[_繁體中文_](README.zh-TW.md)
 
 In computer science, a **queue** is a particular kind of abstract data
 type or collection in which the entities in the collection are

--- a/src/data-structures/queue/README.zh-TW.md
+++ b/src/data-structures/queue/README.zh-TW.md
@@ -1,0 +1,24 @@
+# 佇列
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Русский_](README.ru-RU.md),
+[_日本語_](README.ja-JP.md),
+[_Français_](README.fr-FR.md),
+[_Português_](README.pt-BR.md),
+[_한국어_](README.ko-KR.md),
+[_Українська_](README.uk-UA.md)
+
+在電腦科學中，**佇列**是一種特定的抽象資料型別或集合，其中集合中的元素按照順序排列，對集合的主要（或唯一）操作是將元素加入到尾端位置（稱為 enqueue，入列），以及從前端位置移除元素（稱為 dequeue，出列）。這使得佇列成為先進先出（FIFO, First-In-First-Out）的資料結構。在 FIFO 資料結構中，第一個被加入佇列的元素將會是第一個被移除的。這等同於一旦新元素被加入後，所有在其之前加入的元素都必須先被移除，新元素才能被移除。通常還會提供一個 peek 或 front 操作，用於回傳前端元素的值而不將其移出佇列。佇列是線性資料結構的一個範例，或更抽象地說，是一種循序集合。
+
+先進先出（FIFO）佇列的示意圖
+
+![Queue](./images/queue.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/队列)
+- [YouTube](https://www.youtube.com/watch?v=wjI1WNcIntg&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8&index=3&)

--- a/src/data-structures/stack/README.md
+++ b/src/data-structures/stack/README.md
@@ -7,7 +7,8 @@ _Read this in other languages:_
 [_Français_](README.fr-FR.md),
 [_Português_](README.pt-BR.md),
 [_한국어_](README.ko-KR.md),
-[_Українська_](README.uk-UA.md)
+[_Українська_](README.uk-UA.md),
+[_繁體中文_](README.zh-TW.md)
 
 In computer science, a **stack** is an abstract data type that serves
 as a collection of elements, with two principal operations:

--- a/src/data-structures/stack/README.zh-TW.md
+++ b/src/data-structures/stack/README.zh-TW.md
@@ -1,0 +1,29 @@
+# 堆疊
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Русский_](README.ru-RU.md),
+[_日本語_](README.ja-JP.md),
+[_Français_](README.fr-FR.md),
+[_Português_](README.pt-BR.md),
+[_한국어_](README.ko-KR.md),
+[_Українська_](README.uk-UA.md)
+
+在電腦科學中，**堆疊**是一種作為元素集合的抽象資料型別，具有兩個主要操作：
+
+* **push**：將元素加入集合
+* **pop**：移除最近加入且尚未被移除的元素
+
+元素離開堆疊的順序產生了它的另一個名稱——LIFO（Last In, First Out，後進先出）。此外，peek 操作可以存取堆疊頂端的元素而不修改堆疊。「堆疊」這個名稱來自於一疊物品堆放在一起的比喻——從堆疊頂端取出物品很容易，但要取得堆疊深處的物品可能需要先移開許多其他物品。
+
+堆疊執行時期的 push 和 pop 操作簡單示意圖
+
+![Stack](./images/stack.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/堆栈)
+- [YouTube](https://www.youtube.com/watch?v=wjI1WNcIntg&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8&index=3&)

--- a/src/data-structures/tree/README.md
+++ b/src/data-structures/tree/README.md
@@ -2,7 +2,8 @@
 
 _Read this in other languages:_
 [_简体中文_](README.zh-CN.md),
-[_Português_](README.pt-BR.md)
+[_Português_](README.pt-BR.md),
+[_繁體中文_](README.zh-TW.md)
 
 * [Binary Search Tree](binary-search-tree)
 * [AVL Tree](avl-tree)

--- a/src/data-structures/tree/README.zh-TW.md
+++ b/src/data-structures/tree/README.zh-TW.md
@@ -1,0 +1,27 @@
+# 樹
+
+_以其他語言閱讀：_
+[_English_](README.md),
+[_简体中文_](README.zh-CN.md),
+[_Português_](README.pt-BR.md)
+
+* [二元搜尋樹](binary-search-tree)
+* [AVL 樹](avl-tree)
+* [紅黑樹](red-black-tree)
+* [線段樹](segment-tree) - 包含最小值/最大值/總和的範圍查詢範例
+* [樹狀數組](fenwick-tree)（二元索引樹）
+
+在電腦科學中，**樹**是一種廣泛使用的抽象資料型別（ADT）——或實作此 ADT 的資料結構——它模擬一種階層式的樹狀結構，具有一個根值以及由父節點表示的子樹，呈現為一組鏈結的節點。
+
+樹狀資料結構可以被遞迴地（局部地）定義為節點的集合（從根節點開始），其中每個節點是一個由值和指向其他節點的參考列表（稱為「子節點」）組成的資料結構，並且不允許重複的參考，也沒有參考指向根節點。
+
+一棵簡單的無序樹；在此圖中，標記為 3 的節點有兩個子節點（標記為 2 和 6），以及一個父節點（標記為 2）。最頂端的根節點沒有父節點。
+
+![Tree](./images/tree.jpeg)
+
+*使用 [okso.app](https://okso.app) 製作*
+
+## 參考資料
+
+- [維基百科](https://zh.wikipedia.org/wiki/树_(数据结构))
+- [YouTube](https://www.youtube.com/watch?v=oSWTXtMglKE&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8&index=8)


### PR DESCRIPTION
## Summary
This pull request adds comprehensive Traditional Chinese (繁體中文) translations for the main README and several key data structure documentation files. I have coworked with Claude Code Opus 4.6 to make sure the following information is correct.

## Key Changes
- **Main README (README.zh-TW.md)**: 
  - Updated and improved existing Traditional Chinese translation with better terminology and phrasing
  - Added repo size badge
  - Reorganized content with difficulty levels (B for Beginner, A for Advanced)
  - Expanded algorithm categories with new entries (bits, binary floating-point, prime factors, sieve of Eratosthenes, etc.)
  - Added new sections for cryptography, machine learning, image processing, statistics, and evolutionary algorithms
  - Improved Big O notation table with better formatting
  - Enhanced data structure and sorting algorithm complexity tables
  - Fixed language references (e.g., "Türk" → "Türkçe", "Italiana" → "Italiano")

- **New Data Structure READMEs in Traditional Chinese**:
  - `src/data-structures/linked-list/README.zh-TW.md` - Linked list documentation
  - `src/data-structures/queue/README.zh-TW.md` - Queue documentation
  - `src/data-structures/stack/README.zh-TW.md` - Stack documentation
  - `src/data-structures/hash-table/README.zh-TW.md` - Hash table documentation
  - `src/data-structures/heap/README.zh-TW.md` - Heap documentation
  - `src/data-structures/tree/README.zh-TW.md` - Tree documentation

- **Updated English READMEs**: Added Traditional Chinese language links to existing English documentation files for linked-list, queue, stack, hash-table, heap, and tree data structures

## Notable Details
- All new Traditional Chinese documentation files follow the same structure and format as their English counterparts
- Language references in the main README were corrected for accuracy
- Complexity tables were enhanced with better formatting and additional context
- The difficulty level system (B/A) was consistently applied throughout the algorithm listings

https://claude.ai/code/session_01RftDRB79YtH9PFWHCDrgQz