### PR TITLE
Add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
## Problem
Windows users face ESLint `linebreak-style` errors on fresh clone 
because Git on Windows auto-converts LF to CRLF on checkout.

This causes `npm run lint` to report thousands of errors on Windows
without the contributor changing a single line of code.

## Fix
Added `.gitattributes` to enforce LF line endings across all 
platforms so `npm run lint` passes on Windows, Linux and macOS 
without any manual intervention.

## Testing
- Verified `npm run lint` passes on Windows after this change