### PR TITLE
fix: resolve LinkedList insert tail bug, GraphEdge key caching, and S…

### DIFF
--- a/src/algorithms/graph/strongly-connected-components/stronglyConnectedComponents.js
+++ b/src/algorithms/graph/strongly-connected-components/stronglyConnectedComponents.js
@@ -129,5 +129,10 @@ export default function stronglyConnectedComponents(graph) {
   graph.reverse();
 
   // Do DFS once again on reversed graph.
-  return getSCCSets(graph, verticesByFinishTime);
+  const sccSets = getSCCSets(graph, verticesByFinishTime);
+
+  // Reverse the graph back to its original state.
+  graph.reverse();
+
+  return sccSets;
 }

--- a/src/data-structures/graph/GraphEdge.js
+++ b/src/data-structures/graph/GraphEdge.js
@@ -33,6 +33,8 @@ export default class GraphEdge {
     this.startVertex = this.endVertex;
     this.endVertex = tmp;
 
+    this.key = null;
+
     return this;
   }
 

--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -75,6 +75,9 @@ export default class LinkedList {
       if (currentNode) {
         newNode.next = currentNode.next;
         currentNode.next = newNode;
+        if (!newNode.next) {
+          this.tail = newNode;
+        }
       } else {
         if (this.tail) {
           this.tail.next = newNode;


### PR DESCRIPTION
1. LinkedList: Fixed tail pointer update in insert()
The insert() method previously failed to update the tail pointer when a node was inserted at the very end of the list (i.e., when the new node's next was null). This led to an inconsistent state where the list appeared to have the correct elements, but the tail property pointed to the second-to-last node.

Affected file: src/data-structures/linked-list/LinkedList.js
Fix: Added a check to update this.tail whenever a node is inserted at the end.
2. GraphEdge: Invalidated cached key on reverse()
The GraphEdge class caches its key for performance. However, when the edge was reversed (swapping start and end vertices), the cached key remained stale. This caused issues in the Graph class where the edge mapping would become inconsistent after a graph reversal.

Affected file: src/data-structures/graph/GraphEdge.js
Fix: Modified reverse() to reset this.key = null, ensuring the key is recalculated on the next access.
3. Strongly Connected Components (SCC): Removed destructive side-effect
Kosaraju's algorithm requires reversing the graph in its second pass. Previously, the algorithm modified the input graph in-place but never restored it, leaving the caller's graph in a reversed state.

Affected file: src/algorithms/graph/strongly-connected-components/stronglyConnectedComponents.js
Fix: Added a second graph.reverse() call before returning the result to restore the graph to its original orientation.