### PR TITLE
fix: Fix broken image reference in permutations README

### DIFF
--- a/src/algorithms/sets/permutations/README.md
+++ b/src/algorithms/sets/permutations/README.md
@@ -39,7 +39,7 @@ n * n * n ... (r times) = n^r
 
 ## Cheatsheet
 
-![Permutations and Combinations Overview](./images/overview.png)
+![Permutations and Combinations Overview](./images/permutations-overview.jpeg)
 
 ![Permutations overview](./images/permutations-overview.jpeg)
 


### PR DESCRIPTION
Fixes #2049 - Replace broken image reference ./images/overview.png with the correct file ./images/permutations-overview.jpeg in the permutations README.

This fixes a broken image link that was preventing the permutations documentation from displaying correctly.

**Changes:**
- Updated image path in src/algorithms/sets/permutations/README.md
- Changed from  to 
- The file  exists and is the correct image file