### PR TITLE
chore: fix typo in n-queens test description

### DIFF
--- a/src/algorithms/uncategorized/n-queens/__test__/nQueens.test.js
+++ b/src/algorithms/uncategorized/n-queens/__test__/nQueens.test.js
@@ -1,7 +1,7 @@
 import nQueens from '../nQueens';
 
 describe('nQueens', () => {
-  it('should not hae solution for 3 queens', () => {
+  it('should not have solution for 3 queens', () => {
     const solutions = nQueens(3);
     expect(solutions.length).toBe(0);
   });


### PR DESCRIPTION
## Summary

Fixes # — __
Source issue: 

## Spec

## Problem
The n-queens Jest test description contains a typo: `hae` should be `have`.

## Acceptance criteria
- The test description reads naturally: `should not have solution for 3 queens`.
- No runtime behavior changes are introduced.

## Approach
Fix the typo in the n-queens test name only.

## Files likely touched
- `src/algorithms/uncategorized/n-queens/__test__/nQueens.test.js`

## Risk / blast radius
Very low. This is a test description string only and does not affect algorithm behavior.

## Test plan
- Run the focused n-queens Jest test.
- Run `git diff --check`.

## Work breakdown (TDD)

## TODO
- [x] Fix the typo in the n-queens test description.
- [x] Verify the focused n-queens test still passes.
- [x] Run whitespace diff checks.

## Visual verification


_No screenshots captured (stub or non-UI change)._

## Blockers / open questions



## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] Manual smoke on the affected surface (see screenshots)

---

_Generated by the `auto-github-contributor` skill. The agent followed a red-green-refactor loop and captured visual artefacts under `.auto-pr/screenshots/`._
