### PR TITLE
fix(pt-BR): correções de tradução em queue, insertion-sort e linked-list

### DIFF
--- a/src/algorithms/sorting/insertion-sort/README.pt-BR.md
+++ b/src/algorithms/sorting/insertion-sort/README.pt-BR.md
@@ -3,7 +3,7 @@
 _Leia isso em outros idiomas:_
 [_English_](README.md)
 
-A ordenação por inserção é um algoritmo de ordenação simples que criaa matriz classificada final (ou lista) um item de cada vez.
+A ordenação por inserção é um algoritmo de ordenação simples que cria a matriz classificada final (ou lista) um item de cada vez.
 É muito menos eficiente em grandes listas do que mais algoritmos avançados, como quicksort, heapsort ou merge
 ordenar.
 

--- a/src/data-structures/linked-list/README.pt-BR.md
+++ b/src/data-structures/linked-list/README.pt-BR.md
@@ -149,7 +149,7 @@ end ReverseTraversal
 | :----: | :------: | :------: | :-----: |
 |  O(n)  |  O(n)    |  O(1)    |  O(n)   |
 
-### Complexidade de Espaçø
+### Complexidade de Espaço
 
 O(n)
 

--- a/src/data-structures/queue/README.pt-BR.md
+++ b/src/data-structures/queue/README.pt-BR.md
@@ -18,13 +18,13 @@ um exemplo de uma estrutura de dados linear, ou mais abstratamente uma
 coleção seqüencial.
 
 
-Representação de uma file FIFO (first in, first out)
+Representação de uma fila FIFO (first in, first out)
 
 ![Queue](./images/queue.jpeg)
 
 *Made with [okso.app](https://okso.app)*
 
-## References
+## Referências
 
 - [Wikipedia](https://en.wikipedia.org/wiki/Queue_(abstract_data_type))
 - [YouTube](https://www.youtube.com/watch?v=wjI1WNcIntg&list=PLLXdhg_r2hKA7DPDsunoDZ-Z769jWn4R8&index=3&)


### PR DESCRIPTION
## What

Quatro correções de tradução PT-BR (typos objetivos, sem mudança de conteúdo):

- **`data-structures/queue/README.pt-BR.md`** — "uma **file** FIFO" → "uma **fila** FIFO"
- **`data-structures/queue/README.pt-BR.md`** — heading `## References` → `## Referências` (era o único heading em inglês num arquivo todo em português)
- **`algorithms/sorting/insertion-sort/README.pt-BR.md`** — "que **criaa** matriz" → "que **cria a** matriz"
- **`data-structures/linked-list/README.pt-BR.md`** — "Complexidade de **Espaçø**" → "Complexidade de **Espaço**" (caractere `ø` no lugar de `o`)

All changes are PT-BR translation fixes only.
