### PR TITLE
fix(math): handle negative powers in fast powering algorithm

### DIFF
--- a/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
+++ b/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
@@ -1,6 +1,15 @@
 import fastPowering from '../fastPowering';
 
 describe('fastPowering', () => {
+  it('should compute negative powers correctly', () => {
+    expect(fastPowering(2, -1)).toBe(0.5);
+    expect(fastPowering(2, -2)).toBe(0.25);
+    expect(fastPowering(2, -3)).toBe(0.125);
+    expect(fastPowering(4, -1)).toBe(0.25);
+    expect(fastPowering(5, -2)).toBeCloseTo(0.04, 10);
+    expect(fastPowering(10, -1)).toBe(0.1);
+  });
+
   it('should compute power in log(n) time', () => {
     expect(fastPowering(1, 1)).toBe(1);
     expect(fastPowering(2, 0)).toBe(1);

--- a/src/algorithms/math/fast-powering/fastPowering.js
+++ b/src/algorithms/math/fast-powering/fastPowering.js
@@ -14,6 +14,12 @@ export default function fastPowering(base, power) {
     return 1;
   }
 
+  if (power < 0) {
+    // Negative power means we need to compute the reciprocal.
+    // x^(-n) = 1 / x^n
+    return 1 / fastPowering(base, -power);
+  }
+
   if (power % 2 === 0) {
     // If the power is even...
     // we may recursively redefine the result via twice smaller powers:


### PR DESCRIPTION
## Problem

The `fastPowering` function enters infinite recursion when called with a negative power value.

```js
fastPowering(2, -1); // RangeError: Maximum call stack size exceeded
fastPowering(2, -2); // RangeError: Maximum call stack size exceeded
```

This happens because negative powers never hit the base case (`power === 0`) due to the floor division logic — `Math.floor(-1 / 2)` is `-1`, not `0`.

## Fix

Added handling for negative powers by computing the reciprocal before recursing:

```js
x^(-n) = 1 / x^n
```

This converts the negative power to a positive one and computes the reciprocal.

## Test Coverage

Added test cases for negative powers:
- `fastPowering(2, -1)` → `0.5`
- `fastPowering(2, -2)` → `0.25`
- `fastPowering(2, -3)` → `0.125`
- `fastPowering(4, -1)` → `0.25`
- `fastPowering(5, -2)` → `0.04`
- `fastPowering(10, -1)` → `0.1`

All existing tests continue to pass.