### PR TITLE
fix(math): add input validation for negative numbers in factorial

### DIFF
--- a/src/algorithms/math/factorial/__test__/factorial.test.js
+++ b/src/algorithms/math/factorial/__test__/factorial.test.js
@@ -8,4 +8,16 @@ describe('factorial', () => {
     expect(factorial(8)).toBe(40320);
     expect(factorial(10)).toBe(3628800);
   });
+
+  it('should throw an error for negative numbers', () => {
+    const negativeFactorial = () => {
+      factorial(-1);
+    };
+    expect(negativeFactorial).toThrow('Factorial is not defined for negative numbers');
+
+    const negativeFactorial2 = () => {
+      factorial(-5);
+    };
+    expect(negativeFactorial2).toThrow('Factorial is not defined for negative numbers');
+  });
 });

--- a/src/algorithms/math/factorial/factorial.js
+++ b/src/algorithms/math/factorial/factorial.js
@@ -3,6 +3,11 @@
  * @return {number}
  */
 export default function factorial(number) {
+  // Factorial is not defined for negative numbers.
+  if (number < 0) {
+    throw new Error('Factorial is not defined for negative numbers');
+  }
+
   let result = 1;
 
   for (let i = 2; i <= number; i += 1) {


### PR DESCRIPTION
## Problem

The `factorial` function silently returns `1` for any negative input, which is mathematically incorrect:

```js
factorial(-1); // returns 1 (incorrect — factorial is undefined for negative integers)
factorial(-5); // returns 1 (incorrect)
```

## Fix

Added a guard clause that throws a descriptive error when a negative number is passed, making the function's behavior explicit and preventing silent incorrect results:

```js
factorial(-1); // throws Error: Factorial is not defined for negative numbers
```

## Test Coverage

Added a new test case verifying the error is thrown for negative inputs (`-1`, `-5`). All existing tests continue to pass.