### PR TITLE
refactor: replace deprecated String.prototype.substr() with substring()

### DIFF
--- a/src/algorithms/cryptography/polynomial-hash/__test__/PolynomialHash.test.js
+++ b/src/algorithms/cryptography/polynomial-hash/__test__/PolynomialHash.test.js
@@ -21,12 +21,12 @@ describe('PolynomialHash', () => {
 
         // Check hashing for different word lengths.
         frameSizes.forEach((frameSize) => {
-          let previousWord = text.substr(0, frameSize);
+          let previousWord = text.substring(0, frameSize);
           let previousHash = polynomialHash.hash(previousWord);
 
           // Shift frame through the whole text.
           for (let frameShift = 1; frameShift < (text.length - frameSize); frameShift += 1) {
-            const currentWord = text.substr(frameShift, frameSize);
+            const currentWord = text.substring(frameShift, frameShift + frameSize);
             const currentHash = polynomialHash.hash(currentWord);
             const currentRollingHash = polynomialHash.roll(previousHash, previousWord, currentWord);
 

--- a/src/algorithms/cryptography/polynomial-hash/__test__/SimplePolynomialHash.test.js
+++ b/src/algorithms/cryptography/polynomial-hash/__test__/SimplePolynomialHash.test.js
@@ -18,12 +18,12 @@ describe('PolynomialHash', () => {
 
       // Check hashing for different word lengths.
       frameSizes.forEach((frameSize) => {
-        let previousWord = text.substr(0, frameSize);
+        let previousWord = text.substring(0, frameSize);
         let previousHash = polynomialHash.hash(previousWord);
 
         // Shift frame through the whole text.
         for (let frameShift = 1; frameShift < (text.length - frameSize); frameShift += 1) {
-          const currentWord = text.substr(frameShift, frameSize);
+          const currentWord = text.substring(frameShift, frameShift + frameSize);
           const currentHash = polynomialHash.hash(currentWord);
           const currentRollingHash = polynomialHash.roll(previousHash, previousWord, currentWord);
 

--- a/src/algorithms/string/rabin-karp/rabinKarp.js
+++ b/src/algorithms/string/rabin-karp/rabinKarp.js
@@ -32,7 +32,7 @@ export default function rabinKarp(text, word) {
     // In case of hash collision the strings may not be equal.
     if (
       wordHash === currentFrameHash
-      && text.substr(charIndex, word.length) === word
+      && text.substring(charIndex, charIndex + word.length) === word
     ) {
       return charIndex;
     }


### PR DESCRIPTION
## Problem

`String.prototype.substr()` is a legacy feature defined in Annex B of the ECMAScript specification and is deprecated. It may be removed from future JavaScript engine versions.

The codebase uses `substr()` in 5 places across 3 files.

## Fix

Replaced all `substr(start, length)` calls with `substring(start, start + length)`, which is the modern, standard alternative. The behavior is identical for all cases in this codebase.

### Files changed:
- `src/algorithms/string/rabin-karp/rabinKarp.js` — source code
- `src/algorithms/cryptography/polynomial-hash/__test__/SimplePolynomialHash.test.js` — test
- `src/algorithms/cryptography/polynomial-hash/__test__/PolynomialHash.test.js` — test

### Conversion pattern:
```js
// Before
text.substr(start, length)

// After
text.substring(start, start + length)
```

All 7 affected tests pass.