### PR TITLE
fix: correct JSDoc position range to match code validation (1-70)

### DIFF
--- a/src/algorithms/math/fibonacci/fibonacciNthClosedForm.js
+++ b/src/algorithms/math/fibonacci/fibonacciNthClosedForm.js
@@ -2,7 +2,7 @@
  * Calculate fibonacci number at specific position using closed form function (Binet's formula).
  * @see: https://en.wikipedia.org/wiki/Fibonacci_number#Closed-form_expression
  *
- * @param {number} position - Position number of fibonacci sequence (must be number from 1 to 75).
+ * @param {number} position - Position number of fibonacci sequence (must be number from 1 to 70).
  * @return {number}
  */
 export default function fibonacciClosedForm(position) {


### PR DESCRIPTION
## Description

The JSDoc comment for `fibonacciClosedForm()` states the valid position range is "1 to 75", but the code validates against `topMaxValidPosition = 70`.

```javascript
// Current JSDoc (line 7)
@param {number} position - Position number of fibonacci sequence (must be number from 1 to 75).

// Actual validation (line 10)
const topMaxValidPosition = 70;
```

## Changes

- Updated JSDoc `@param` description to reflect the actual valid range (1 to 70)

## Verification

The error message in the code already correctly uses the `topMaxValidPosition` variable:
```javascript
throw new Error(`Can't handle position smaller than 1 or greater than ${topMaxValidPosition}`);
```

This PR only fixes the documentation to match the implementation.