### PR TITLE
fix: handle zero and negative numbers in RadixSort

### DIFF
--- a/src/algorithms/sorting/radix-sort/RadixSort.js
+++ b/src/algorithms/sorting/radix-sort/RadixSort.js
@@ -113,7 +113,10 @@ export default class RadixSort extends Sort {
    */
   getLengthOfLongestElement(array) {
     if (this.isArrayOfNumbers(array)) {
-      return Math.floor(Math.log10(Math.max(...array))) + 1;
+      const max = Math.max(...array);
+      // Handle edge cases where max is 0 or negative
+      if (max <= 0) return 1;
+      return Math.floor(Math.log10(max)) + 1;
     }
 
     return array.reduce((acc, val) => {


### PR DESCRIPTION
## Bug Description

`RadixSort.getLengthOfLongestElement()` fails when the input array contains only zeros or negative numbers:

- `Math.log10(0)` returns `-Infinity`, causing `numPasses` to be `-Infinity`
- `Math.log10(-N)` returns `NaN`, causing `numPasses` to be `NaN`

In both cases, the sorting loop (`for (let currentIndex = 0; currentIndex < numPasses; ...)`) never executes, and the unsorted array is returned as-is.

## Steps to Reproduce

```javascript
const sorter = new RadixSort();
sorter.sort([-3, -1, -2]); // Returns [-3, -1, -2] (not sorted!)
sorter.sort([0, 0, 0]);    // Returns [0, 0, 0] (correct by accident)
```

## Fix

Added an early return in `getLengthOfLongestElement()` to handle edge cases where the maximum value is 0 or negative:

```javascript
getLengthOfLongestElement(array) {
    if (this.isArrayOfNumbers(array)) {
      const max = Math.max(...array);
      // Handle edge cases where max is 0 or negative
      if (max <= 0) return 1;
      return Math.floor(Math.log10(max)) + 1;
    }
    // ...
}
```

## Testing

The existing test suite (`SortTester.testSort`) includes `[3, 4, 2, 1, 0, 0, 4, 3, 4, 2]` which works correctly. However, arrays of purely negative numbers are not tested and reveal this bug.

Note: Radix Sort has inherent limitations with negative numbers. A complete fix would require splitting the array by sign and merging results. This PR addresses the immediate `NaN`/`-Infinity` issue to prevent silent incorrect behavior.