### PR TITLE
Fix correctness bugs found in a full-codebase audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Below is the list of some of the most used Big O notations and their performance
 | **Array**               | 1         | n         | n         | n         |           |
 | **Stack**               | n         | n         | 1         | 1         |           |
 | **Queue**               | n         | n         | 1         | 1         |           |
+| **Deque**               | n         | n         | 1         | 1         | Insertion and deletion are O(1) at both the front and the back |
 | **Linked List**         | n         | n         | 1         | n         |           |
 | **Hash Table**          | -         | n         | n         | n         | In case of perfect hash function costs would be O(1) |
 | **Binary Search Tree**  | n         | n         | n         | n         | In case of balanced tree costs would be O(log(n)) |
@@ -357,7 +358,7 @@ Below is the list of some of the most used Big O notations and their performance
 | **Bubble sort**       | n               | n<sup>2</sup>       | n<sup>2</sup>       | 1         | Yes       |           |
 | **Insertion sort**    | n               | n<sup>2</sup>       | n<sup>2</sup>       | 1         | Yes       |           |
 | **Selection sort**    | n<sup>2</sup>   | n<sup>2</sup>       | n<sup>2</sup>       | 1         | No        |           |
-| **Heap sort**         | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | 1         | No        |           |
+| **Heap sort**         | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | 1         | No        | Classic heapsort is in-place; this repo's implementation copies the items into a heap and thus uses O(n) memory |
 | **Merge sort**        | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | n         | Yes       |           |
 | **Quick sort**        | n&nbsp;log(n)   | n&nbsp;log(n)       | n<sup>2</sup>       | log(n)    | No        | Quicksort is usually done in-place with O(log(n)) stack space |
 | **Shell sort**        | n&nbsp;log(n)   | depends on gap sequence   | n&nbsp;(log(n))<sup>2</sup>  | 1         | No         |           |

--- a/src/algorithms/cryptography/hill-cipher/hillCipher.js
+++ b/src/algorithms/cryptography/hill-cipher/hillCipher.js
@@ -23,7 +23,7 @@ const generateKeyMatrix = (keyString) => {
     // Callback to get a value of each matrix cell.
     // The order the matrix is being filled in is from left to right, from top to bottom.
     () => {
-      // A → 0, B → 1, ..., a → 32, b → 33, ...
+      // A → 0, B → 1, ..., Z → 25
       const charCodeShifted = (keyString.codePointAt(keyStringIndex)) % alphabetCodeShift;
       keyStringIndex += 1;
       return charCodeShifted;
@@ -63,8 +63,11 @@ export function hillCipherEncrypt(message, keyString) {
     throw new Error('The message and key string can only contain letters');
   }
 
-  const keyMatrix = generateKeyMatrix(keyString);
-  const messageVector = generateMessageVector(message);
+  // The cipher works with the 26-letter alphabet where A → 0, ..., Z → 25.
+  // Normalize the case so that lowercase letters map to the same numbers
+  // as their uppercase counterparts.
+  const keyMatrix = generateKeyMatrix(keyString.toUpperCase());
+  const messageVector = generateMessageVector(message.toUpperCase());
 
   // keyString.length must equal to square of message.length
   if (keyMatrix.length !== message.length) {

--- a/src/algorithms/cryptography/polynomial-hash/PolynomialHash.js
+++ b/src/algorithms/cryptography/polynomial-hash/PolynomialHash.js
@@ -39,7 +39,8 @@ export default class PolynomialHash {
    * Recalculates the hash representation of a word so that it isn't
    * necessary to traverse the whole word again.
    *
-   * Time complexity: O(1).
+   * Time complexity: O(word.length) because of the multiplier
+   * re-calculation loop (hash update itself takes O(1) time).
    *
    * @param {number} prevHash
    * @param {string} prevWord
@@ -49,11 +50,16 @@ export default class PolynomialHash {
   roll(prevHash, prevWord, newWord) {
     let hash = prevHash;
 
-    const prevValue = this.charToNumber(prevWord[0]);
-    const newValue = this.charToNumber(newWord[newWord.length - 1]);
+    // Use code points (and not UTF-16 code units) to be consistent with
+    // the hash() method and to support surrogate pairs (astral symbols).
+    const prevWordChars = Array.from(prevWord);
+    const newWordChars = Array.from(newWord);
+
+    const prevValue = this.charToNumber(prevWordChars[0]);
+    const newValue = this.charToNumber(newWordChars[newWordChars.length - 1]);
 
     let prevValueMultiplier = 1;
-    for (let i = 1; i < prevWord.length; i += 1) {
+    for (let i = 1; i < prevWordChars.length; i += 1) {
       prevValueMultiplier *= this.base;
       prevValueMultiplier %= this.modulus;
     }

--- a/src/algorithms/cryptography/polynomial-hash/README.md
+++ b/src/algorithms/cryptography/polynomial-hash/README.md
@@ -37,9 +37,9 @@ The *Rabin–Karp string search algorithm* is often explained using a very simpl
 rolling hash function that only uses multiplications and 
 additions - **polynomial rolling hash**:
 
-> H(s<sub>0</sub>, s<sub>1</sub>, ..., s<sub>k</sub>) = s<sub>0</sub> * p<sup>k-1</sup> + s<sub>1</sub> * p<sup>k-2</sup> + ... + s<sub>k</sub> * p<sup>0</sup>
+> H(s<sub>0</sub>, s<sub>1</sub>, ..., s<sub>k</sub>) = s<sub>0</sub> * p<sup>k</sup> + s<sub>1</sub> * p<sup>k-1</sup> + ... + s<sub>k</sub> * p<sup>0</sup>
 
-where `p` is a constant, and *(s<sub>1</sub>, ... , s<sub>k</sub>)* are the input
+where `p` is a constant, and *(s<sub>0</sub>, ... , s<sub>k</sub>)* are the input
 characters.
 
 For example we can convert short strings to key numbers by multiplying digit codes by 
@@ -50,7 +50,7 @@ by calculating:
 
 In order to avoid manipulating huge `H` values, all math is done modulo `M`.
 
-> H(s<sub>0</sub>, s<sub>1</sub>, ..., s<sub>k</sub>) = (s<sub>0</sub> * p<sup>k-1</sup> + s<sub>1</sub> * p<sup>k-2</sup> + ... + s<sub>k</sub> * p<sup>0</sup>) mod M
+> H(s<sub>0</sub>, s<sub>1</sub>, ..., s<sub>k</sub>) = (s<sub>0</sub> * p<sup>k</sup> + s<sub>1</sub> * p<sup>k-1</sup> + ... + s<sub>k</sub> * p<sup>0</sup>) mod M
 
 A careful choice of the parameters `M`, `p` is important to obtain “good”
 properties of the hash function, i.e., low collision rate.
@@ -106,7 +106,7 @@ function hash(key, arraySize) {
 Polynomial hashing has a rolling property: the fingerprints can be updated 
 efficiently when symbols are added or removed at the ends of the string
 (provided that an array of powers of p modulo M of sufficient length is stored).
-The popular Rabin–Karp pattern matching algorithm is based on this property
+The popular Rabin–Karp pattern matching algorithm is based on this property.
 
 ## References
 

--- a/src/algorithms/cryptography/rail-fence-cipher/__test__/railFenceCipher.test.js
+++ b/src/algorithms/cryptography/rail-fence-cipher/__test__/railFenceCipher.test.js
@@ -40,4 +40,12 @@ describe('railFenceCipher', () => {
       'THEYAREATTACKINGFROMTHENORTH',
     );
   });
+
+  it('leaves the message unchanged when there is a single rail', () => {
+    // A single-rail fence can't zig-zag, so the cipher is the identity.
+    expect(encodeRailFenceCipher('abc', 1)).toBe('abc');
+    expect(decodeRailFenceCipher('abc', 1)).toBe('abc');
+    expect(encodeRailFenceCipher('', 1)).toBe('');
+    expect(decodeRailFenceCipher('', 1)).toBe('');
+  });
 });

--- a/src/algorithms/cryptography/rail-fence-cipher/railFenceCipher.js
+++ b/src/algorithms/cryptography/rail-fence-cipher/railFenceCipher.js
@@ -201,6 +201,12 @@ const decodeFence = (params) => {
  * @returns {string} - Encoded string
  */
 export const encodeRailFenceCipher = (string, railCount) => {
+  // A fence with a single rail (or no rails at all) can't zig-zag
+  // and thus leaves the message unchanged.
+  if (railCount <= 1) {
+    return string;
+  }
+
   const fence = buildFence(railCount);
 
   const filledFence = fillEncodeFence({
@@ -221,6 +227,12 @@ export const encodeRailFenceCipher = (string, railCount) => {
  * @returns {string} - Decoded string.
  */
 export const decodeRailFenceCipher = (string, railCount) => {
+  // A fence with a single rail (or no rails at all) can't zig-zag
+  // and thus leaves the message unchanged.
+  if (railCount <= 1) {
+    return string;
+  }
+
   const strLen = string.length;
   const emptyFence = buildFence(railCount);
   const filledFence = fillDecodeFence({

--- a/src/algorithms/graph/articulation-points/__test__/articulationPoints.test.js
+++ b/src/algorithms/graph/articulation-points/__test__/articulationPoints.test.js
@@ -229,4 +229,35 @@ describe('articulationPoints', () => {
     expect(articulationPointsSet.length).toBe(1);
     expect(articulationPointsSet[0].getKey()).toBe(vertexC.getKey());
   });
+
+  it('should find articulation points in all components of disconnected graph', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+    const vertexE = new GraphVertex('E');
+    const vertexF = new GraphVertex('F');
+
+    // First component is a path "A - B - C" with articulation point B.
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBC = new GraphEdge(vertexB, vertexC);
+
+    // Second component is a path "D - E - F" with articulation point E.
+    const edgeDE = new GraphEdge(vertexD, vertexE);
+    const edgeEF = new GraphEdge(vertexE, vertexF);
+
+    const graph = new Graph();
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeDE)
+      .addEdge(edgeEF);
+
+    const articulationPointsSet = Object.values(articulationPoints(graph));
+
+    expect(articulationPointsSet.length).toBe(2);
+    expect(articulationPointsSet[0].getKey()).toBe(vertexB.getKey());
+    expect(articulationPointsSet[1].getKey()).toBe(vertexE.getKey());
+  });
 });

--- a/src/algorithms/graph/articulation-points/articulationPoints.js
+++ b/src/algorithms/graph/articulation-points/articulationPoints.js
@@ -29,8 +29,9 @@ export default function articulationPoints(graph) {
   // Time needed to discover to the current vertex.
   let discoveryTime = 0;
 
-  // Peek the start vertex for DFS traversal.
-  const startVertex = graph.getAllVertices()[0];
+  // Root vertex of the graph component that is currently being traversed.
+  // The graph might be disconnected thus every component will have its own root.
+  let startVertex = null;
 
   const dfsCallbacks = {
     /**
@@ -106,8 +107,16 @@ export default function articulationPoints(graph) {
     },
   };
 
-  // Do Depth First Search traversal over submitted graph.
-  depthFirstSearch(graph, startVertex, dfsCallbacks);
+  // Do Depth First Search traversal over all graph components since the graph
+  // might be disconnected. Every unvisited vertex starts the traversal of its
+  // component and becomes the root of that component. Notice that discovery
+  // time keeps on incrementing from component to component.
+  graph.getAllVertices().forEach((vertex) => {
+    if (!visitedSet[vertex.getKey()]) {
+      startVertex = vertex;
+      depthFirstSearch(graph, startVertex, dfsCallbacks);
+    }
+  });
 
   return articulationPointsSet;
 }

--- a/src/algorithms/graph/bellman-ford/__test__/bellmanFord.test.js
+++ b/src/algorithms/graph/bellman-ford/__test__/bellmanFord.test.js
@@ -114,4 +114,28 @@ describe('bellmanFord', () => {
     expect(previousVertices.A.getKey()).toBe('D');
     expect(previousVertices.D.getKey()).toBe('E');
   });
+
+  it('should throw an error in case of negative weight cycle', () => {
+    function bellmanFordNegativeCycle() {
+      const vertexA = new GraphVertex('A');
+      const vertexB = new GraphVertex('B');
+      const vertexC = new GraphVertex('C');
+
+      // Cycle "B - C - B" has total weight of (-3 + 1) = -2. It means that
+      // the shortest paths may be infinitely improved by walking the cycle.
+      const edgeAB = new GraphEdge(vertexA, vertexB, 1);
+      const edgeBC = new GraphEdge(vertexB, vertexC, -3);
+      const edgeCB = new GraphEdge(vertexC, vertexB, 1);
+
+      const graph = new Graph(true);
+      graph
+        .addEdge(edgeAB)
+        .addEdge(edgeBC)
+        .addEdge(edgeCB);
+
+      bellmanFord(graph, vertexA);
+    }
+
+    expect(bellmanFordNegativeCycle).toThrow('Graph contains a negative weight cycle');
+  });
 });

--- a/src/algorithms/graph/bellman-ford/bellmanFord.js
+++ b/src/algorithms/graph/bellman-ford/bellmanFord.js
@@ -38,6 +38,20 @@ export default function bellmanFord(graph, startVertex) {
     });
   }
 
+  // Do one more relaxation round over all the edges. After (|V| - 1) iterations
+  // all the distances must be final. Thus if any distance may still be improved
+  // then the graph must contain a negative weight cycle.
+  Object.keys(distances).forEach((vertexKey) => {
+    const vertex = graph.getVertexByKey(vertexKey);
+
+    graph.getNeighbors(vertex).forEach((neighbor) => {
+      const edge = graph.findEdge(vertex, neighbor);
+      if (distances[vertex.getKey()] + edge.weight < distances[neighbor.getKey()]) {
+        throw new Error('Graph contains a negative weight cycle');
+      }
+    });
+  });
+
   return {
     distances,
     previousVertices,

--- a/src/algorithms/graph/breadth-first-search/README.md
+++ b/src/algorithms/graph/breadth-first-search/README.md
@@ -1,7 +1,7 @@
 # Breadth-First Search (BFS)
 
-Breadth-first search (BFS) is an algorithm for traversing, 
-searching tree, or graph data structures. It starts at
+Breadth-first search (BFS) is an algorithm for traversing 
+or searching tree or graph data structures. It starts at
 the tree root (or some arbitrary node of a graph, sometimes 
 referred to as a 'search key') and explores the neighbor
 nodes first, before moving to the next level neighbors.

--- a/src/algorithms/graph/breadth-first-search/__test__/breadthFirstSearch.test.js
+++ b/src/algorithms/graph/breadth-first-search/__test__/breadthFirstSearch.test.js
@@ -171,4 +171,35 @@ describe('breadthFirstSearch', () => {
       expect(params.previousVertex).toEqual(leaveVertexParamsMap[callIndex].previousVertex);
     }
   });
+
+  it('should enter each vertex of directed cycle exactly once by default', () => {
+    const graph = new Graph(true);
+
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+
+    // Directed triangle "A -> B -> C -> A" that leads back to the start vertex.
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBC = new GraphEdge(vertexB, vertexC);
+    const edgeCA = new GraphEdge(vertexC, vertexA);
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCA);
+
+    const enterVertexCallback = jest.fn();
+
+    breadthFirstSearch(graph, vertexA, {
+      enterVertex: enterVertexCallback,
+    });
+
+    expect(enterVertexCallback).toHaveBeenCalledTimes(3);
+
+    const enteredVertices = enterVertexCallback.mock.calls.map(
+      (call) => call[0].currentVertex.getKey(),
+    );
+    expect(enteredVertices).toEqual(['A', 'B', 'C']);
+  });
 });

--- a/src/algorithms/graph/breadth-first-search/breadthFirstSearch.js
+++ b/src/algorithms/graph/breadth-first-search/breadthFirstSearch.js
@@ -24,7 +24,10 @@ function initCallbacks(callbacks = {}) {
   const allowTraversalCallback = (
     () => {
       const seen = {};
-      return ({ nextVertex }) => {
+      return ({ currentVertex, nextVertex }) => {
+        // Mark current vertex as seen as well so that traversal would never
+        // get back to it (i.e. when the cycle leads back to the start vertex).
+        seen[currentVertex.getKey()] = true;
         if (!seen[nextVertex.getKey()]) {
           seen[nextVertex.getKey()] = true;
           return true;

--- a/src/algorithms/graph/bridges/__test__/graphBridges.test.js
+++ b/src/algorithms/graph/bridges/__test__/graphBridges.test.js
@@ -200,4 +200,35 @@ describe('graphBridges', () => {
     expect(bridges.length).toBe(1);
     expect(bridges[0].getKey()).toBe(edgeCD.getKey());
   });
+
+  it('should find bridges in all components of disconnected graph', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+    const vertexE = new GraphVertex('E');
+
+    // First component "A - B" consists of one bridge.
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+
+    // Second component "C - D - E" consists of two more bridges.
+    const edgeCD = new GraphEdge(vertexC, vertexD);
+    const edgeDE = new GraphEdge(vertexD, vertexE);
+
+    const graph = new Graph();
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeCD)
+      .addEdge(edgeDE);
+
+    const bridges = Object.values(graphBridges(graph));
+
+    expect(bridges.length).toBe(3);
+    expect(bridges.map((bridge) => bridge.getKey()).sort()).toEqual([
+      edgeAB.getKey(),
+      edgeCD.getKey(),
+      edgeDE.getKey(),
+    ].sort());
+  });
 });

--- a/src/algorithms/graph/bridges/graphBridges.js
+++ b/src/algorithms/graph/bridges/graphBridges.js
@@ -24,9 +24,6 @@ export default function graphBridges(graph) {
   // Time needed to discover to the current vertex.
   let discoveryTime = 0;
 
-  // Peek the start vertex for DFS traversal.
-  const startVertex = graph.getAllVertices()[0];
-
   const dfsCallbacks = {
     /**
      * @param {GraphVertex} currentVertex
@@ -88,8 +85,14 @@ export default function graphBridges(graph) {
     },
   };
 
-  // Do Depth First Search traversal over submitted graph.
-  depthFirstSearch(graph, startVertex, dfsCallbacks);
+  // Do Depth First Search traversal over all graph components since the graph
+  // might be disconnected. Every unvisited vertex starts the traversal of its
+  // own component.
+  graph.getAllVertices().forEach((startVertex) => {
+    if (!visitedSet[startVertex.getKey()]) {
+      depthFirstSearch(graph, startVertex, dfsCallbacks);
+    }
+  });
 
   return bridges;
 }

--- a/src/algorithms/graph/depth-first-search/__test__/depthFirstSearch.test.js
+++ b/src/algorithms/graph/depth-first-search/__test__/depthFirstSearch.test.js
@@ -162,4 +162,35 @@ describe('depthFirstSearch', () => {
       expect(params.previousVertex).toEqual(leaveVertexParamsMap[callIndex].previousVertex);
     }
   });
+
+  it('should enter each vertex of directed cycle exactly once by default', () => {
+    const graph = new Graph(true);
+
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+
+    // Directed triangle "A -> B -> C -> A" that leads back to the start vertex.
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBC = new GraphEdge(vertexB, vertexC);
+    const edgeCA = new GraphEdge(vertexC, vertexA);
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCA);
+
+    const enterVertexCallback = jest.fn();
+
+    depthFirstSearch(graph, vertexA, {
+      enterVertex: enterVertexCallback,
+    });
+
+    expect(enterVertexCallback).toHaveBeenCalledTimes(3);
+
+    const enteredVertices = enterVertexCallback.mock.calls.map(
+      (call) => call[0].currentVertex.getKey(),
+    );
+    expect(enteredVertices).toEqual(['A', 'B', 'C']);
+  });
 });

--- a/src/algorithms/graph/depth-first-search/depthFirstSearch.js
+++ b/src/algorithms/graph/depth-first-search/depthFirstSearch.js
@@ -22,7 +22,10 @@ function initCallbacks(callbacks = {}) {
   const allowTraversalCallback = (
     () => {
       const seen = {};
-      return ({ nextVertex }) => {
+      return ({ currentVertex, nextVertex }) => {
+        // Mark current vertex as seen as well so that traversal would never
+        // get back to it (i.e. when the cycle leads back to the start vertex).
+        seen[currentVertex.getKey()] = true;
         if (!seen[nextVertex.getKey()]) {
           seen[nextVertex.getKey()] = true;
           return true;

--- a/src/algorithms/graph/detect-cycle/README.md
+++ b/src/algorithms/graph/detect-cycle/README.md
@@ -16,7 +16,7 @@ to the later of the two vertices in the sequence.
 The choice of starting vertex is not important: traversing the same cyclic 
 sequence of edges from different starting vertices produces the same closed walk.
 
-A **simple cycle may** be defined either as a closed walk with no repetitions of 
+A **simple cycle** may be defined either as a closed walk with no repetitions of 
 vertices and edges allowed, other than the repetition of the starting and ending 
 vertex, or as the set of edges in such a walk. The two definitions are equivalent 
 in directed graphs, where simple cycles are also called directed cycles: the cyclic 

--- a/src/algorithms/graph/detect-cycle/__test__/detectUndirectedCycle.test.js
+++ b/src/algorithms/graph/detect-cycle/__test__/detectUndirectedCycle.test.js
@@ -38,4 +38,33 @@ describe('detectUndirectedCycle', () => {
       E: vertexB,
     });
   });
+
+  it('should detect cycle that is hidden in the second graph component', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+    const vertexE = new GraphVertex('E');
+
+    // First component "A - B" has no cycles.
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+
+    // Second component "C - D - E - C" forms a cycle.
+    const edgeCD = new GraphEdge(vertexC, vertexD);
+    const edgeDE = new GraphEdge(vertexD, vertexE);
+    const edgeEC = new GraphEdge(vertexE, vertexC);
+
+    const graph = new Graph();
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeCD)
+      .addEdge(edgeDE)
+      .addEdge(edgeEC);
+
+    expect(detectUndirectedCycle(graph)).toEqual({
+      C: vertexE,
+      E: vertexD,
+      D: vertexC,
+    });
+  });
 });

--- a/src/algorithms/graph/detect-cycle/detectUndirectedCycle.js
+++ b/src/algorithms/graph/detect-cycle/detectUndirectedCycle.js
@@ -51,9 +51,14 @@ export default function detectUndirectedCycle(graph) {
     },
   };
 
-  // Start DFS traversing.
-  const startVertex = graph.getAllVertices()[0];
-  depthFirstSearch(graph, startVertex, callbacks);
+  // Start DFS traversing. The graph might be disconnected thus we need to run
+  // DFS from every unvisited vertex to make sure that all graph components
+  // are being checked for cycles.
+  graph.getAllVertices().forEach((startVertex) => {
+    if (!cycle && !visitedVertices[startVertex.getKey()]) {
+      depthFirstSearch(graph, startVertex, callbacks);
+    }
+  });
 
   return cycle;
 }

--- a/src/algorithms/graph/eulerian-path/__test__/eulerianPath.test.js
+++ b/src/algorithms/graph/eulerian-path/__test__/eulerianPath.test.js
@@ -136,4 +136,107 @@ describe('eulerianPath', () => {
     expect(eulerianPathSet[8].getKey()).toBe(vertexG.getKey());
     expect(eulerianPathSet[9].getKey()).toBe(vertexF.getKey());
   });
+
+  it('should throw an error for directed graph', () => {
+    function findEulerianPathInDirectedGraph() {
+      const vertexA = new GraphVertex('A');
+      const vertexB = new GraphVertex('B');
+
+      const edgeAB = new GraphEdge(vertexA, vertexB);
+
+      const graph = new Graph(true);
+      graph.addEdge(edgeAB);
+
+      eulerianPath(graph);
+    }
+
+    expect(findEulerianPathInDirectedGraph).toThrow(
+      'Eulerian path algorithm works only for undirected graphs',
+    );
+  });
+
+  it('should throw an error for disconnected graph', () => {
+    function findEulerianPathInDisconnectedGraph() {
+      const vertexA = new GraphVertex('A');
+      const vertexB = new GraphVertex('B');
+      const vertexC = new GraphVertex('C');
+      const vertexD = new GraphVertex('D');
+      const vertexE = new GraphVertex('E');
+      const vertexF = new GraphVertex('F');
+
+      // Two disjoint triangles. All the vertices have even degree but it is
+      // still not possible to visit all graph edges in one pass.
+      const edgeAB = new GraphEdge(vertexA, vertexB);
+      const edgeBC = new GraphEdge(vertexB, vertexC);
+      const edgeCA = new GraphEdge(vertexC, vertexA);
+      const edgeDE = new GraphEdge(vertexD, vertexE);
+      const edgeEF = new GraphEdge(vertexE, vertexF);
+      const edgeFD = new GraphEdge(vertexF, vertexD);
+
+      const graph = new Graph();
+      graph
+        .addEdge(edgeAB)
+        .addEdge(edgeBC)
+        .addEdge(edgeCA)
+        .addEdge(edgeDE)
+        .addEdge(edgeEF)
+        .addEdge(edgeFD);
+
+      eulerianPath(graph);
+    }
+
+    expect(findEulerianPathInDisconnectedGraph).toThrow(
+      'Eulerian path exists only in connected graphs',
+    );
+  });
+
+  it('should find Eulerian Path when the start vertex gets isolated during traversal', () => {
+    const vertexX = new GraphVertex('X');
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+
+    const edgeXA = new GraphEdge(vertexX, vertexA);
+    const edgeAD = new GraphEdge(vertexA, vertexD);
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBC = new GraphEdge(vertexB, vertexC);
+    const edgeCA = new GraphEdge(vertexC, vertexA);
+
+    const graph = new Graph();
+
+    graph
+      .addEdge(edgeXA)
+      .addEdge(edgeAD)
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCA);
+
+    // Remember all graph edges as pairs of vertex keys before the traversal
+    // since Fleury's algorithm deletes graph edges while walking through them.
+    const notVisitedEdges = graph.getAllEdges().map((edge) => {
+      return [edge.startVertex.getKey(), edge.endVertex.getKey()];
+    });
+
+    const eulerianPathSet = eulerianPath(graph);
+
+    expect(eulerianPathSet.length).toBe(notVisitedEdges.length + 1);
+
+    // Check that every step of the path walks through one of the not visited
+    // edges and that every edge is being visited exactly once.
+    for (let vertexIndex = 1; vertexIndex < eulerianPathSet.length; vertexIndex += 1) {
+      const fromKey = eulerianPathSet[vertexIndex - 1].getKey();
+      const toKey = eulerianPathSet[vertexIndex].getKey();
+
+      const edgeIndex = notVisitedEdges.findIndex((edge) => {
+        return (edge[0] === fromKey && edge[1] === toKey)
+          || (edge[0] === toKey && edge[1] === fromKey);
+      });
+
+      expect(edgeIndex).not.toBe(-1);
+      notVisitedEdges.splice(edgeIndex, 1);
+    }
+
+    expect(notVisitedEdges.length).toBe(0);
+  });
 });

--- a/src/algorithms/graph/eulerian-path/eulerianPath.js
+++ b/src/algorithms/graph/eulerian-path/eulerianPath.js
@@ -1,4 +1,5 @@
 import graphBridges from '../bridges/graphBridges';
+import depthFirstSearch from '../depth-first-search/depthFirstSearch';
 
 /**
  * Fleury's algorithm of finding Eulerian Path (visit all graph edges exactly once).
@@ -7,6 +8,32 @@ import graphBridges from '../bridges/graphBridges';
  * @return {GraphVertex[]}
  */
 export default function eulerianPath(graph) {
+  // It should fire error if graph is directed since the algorithm works only
+  // for undirected graphs.
+  if (graph.isDirected) {
+    throw new Error('Eulerian path algorithm works only for undirected graphs');
+  }
+
+  // The algorithm works only for connected graphs. Check that every vertex
+  // that has edges is reachable from any other such vertex. Otherwise it is
+  // not possible to walk through all the edges in one pass.
+  const verticesWithEdges = graph.getAllVertices().filter((vertex) => vertex.getDegree() > 0);
+
+  if (verticesWithEdges.length) {
+    // Do DFS from the first vertex that has edges and collect reached vertices.
+    const reachedVertices = {};
+    depthFirstSearch(graph, verticesWithEdges[0], {
+      enterVertex: ({ currentVertex }) => {
+        reachedVertices[currentVertex.getKey()] = currentVertex;
+      },
+      allowTraversal: ({ nextVertex }) => !reachedVertices[nextVertex.getKey()],
+    });
+
+    if (Object.keys(reachedVertices).length !== verticesWithEdges.length) {
+      throw new Error('Eulerian path exists only in connected graphs');
+    }
+  }
+
   const eulerianPathVertices = [];
 
   // Set that contains all vertices with even rank (number of neighbors).

--- a/src/algorithms/graph/floyd-warshall/README.md
+++ b/src/algorithms/graph/floyd-warshall/README.md
@@ -55,7 +55,7 @@ In the tables below `i` is row numbers and `j` is column numbers.
 | **1** | 0   | ∞   | −2  | ∞   |
 | **2** | 4   | 0   |  2  | ∞   |
 | **3** | ∞   | ∞   |  0  | 2   |
-| **4** | ∞   | −   |  ∞  | 0   |
+| **4** | ∞   | −1  |  ∞  | 0   |
 
 
 **k = 2**

--- a/src/algorithms/graph/floyd-warshall/__test__/floydWarshall.test.js
+++ b/src/algorithms/graph/floyd-warshall/__test__/floydWarshall.test.js
@@ -77,11 +77,13 @@ describe('floydWarshall', () => {
     expect(distances[vertexAIndex][vertexGIndex]).toBe(12);
     expect(distances[vertexAIndex][vertexFIndex]).toBe(11);
 
-    expect(nextVertices[vertexAIndex][vertexFIndex]).toBe(vertexD);
+    // nextVertices[x][y] contains the next vertex after x on the shortest path
+    // from x to y (i.e. the shortest path from A to F is A -> B -> D -> F).
+    expect(nextVertices[vertexAIndex][vertexFIndex]).toBe(vertexB);
     expect(nextVertices[vertexAIndex][vertexDIndex]).toBe(vertexB);
-    expect(nextVertices[vertexAIndex][vertexBIndex]).toBe(vertexA);
+    expect(nextVertices[vertexAIndex][vertexBIndex]).toBe(vertexB);
     expect(nextVertices[vertexAIndex][vertexGIndex]).toBe(vertexE);
-    expect(nextVertices[vertexAIndex][vertexCIndex]).toBe(vertexA);
+    expect(nextVertices[vertexAIndex][vertexCIndex]).toBe(vertexC);
     expect(nextVertices[vertexAIndex][vertexAIndex]).toBe(null);
     expect(nextVertices[vertexAIndex][vertexHIndex]).toBe(null);
   });
@@ -140,11 +142,13 @@ describe('floydWarshall', () => {
       [2, 5, 7, 0],
     ]);
 
-    expect(nextVertices[vertexAIndex][vertexDIndex]).toBe(vertexC);
+    // nextVertices[x][y] contains the next vertex after x on the shortest path
+    // from x to y (i.e. the shortest path from A to D is A -> B -> C -> D).
+    expect(nextVertices[vertexAIndex][vertexDIndex]).toBe(vertexB);
     expect(nextVertices[vertexAIndex][vertexCIndex]).toBe(vertexB);
     expect(nextVertices[vertexBIndex][vertexDIndex]).toBe(vertexC);
     expect(nextVertices[vertexAIndex][vertexAIndex]).toBe(null);
-    expect(nextVertices[vertexAIndex][vertexBIndex]).toBe(vertexA);
+    expect(nextVertices[vertexAIndex][vertexBIndex]).toBe(vertexB);
   });
 
   it('should find minimum paths to all vertices for directed graph with negative edge weights', () => {
@@ -208,13 +212,51 @@ describe('floydWarshall', () => {
     expect(distances[vertexFIndex][vertexDIndex]).toBe(9);
     expect(distances[vertexFIndex][vertexEIndex]).toBe(8);
 
+    // nextVertices[x][y] contains the next vertex after x on the shortest path
+    // from x to y (i.e. the shortest path from F to B is F -> E -> D -> A -> C -> B).
     expect(nextVertices[vertexFIndex][vertexGIndex]).toBe(null);
     expect(nextVertices[vertexFIndex][vertexFIndex]).toBe(null);
     expect(nextVertices[vertexAIndex][vertexBIndex]).toBe(vertexC);
-    expect(nextVertices[vertexAIndex][vertexCIndex]).toBe(vertexA);
+    expect(nextVertices[vertexAIndex][vertexCIndex]).toBe(vertexC);
     expect(nextVertices[vertexFIndex][vertexBIndex]).toBe(vertexE);
     expect(nextVertices[vertexEIndex][vertexBIndex]).toBe(vertexD);
-    expect(nextVertices[vertexDIndex][vertexBIndex]).toBe(vertexC);
-    expect(nextVertices[vertexCIndex][vertexBIndex]).toBe(vertexC);
+    expect(nextVertices[vertexDIndex][vertexBIndex]).toBe(vertexA);
+    expect(nextVertices[vertexCIndex][vertexBIndex]).toBe(vertexB);
+  });
+
+  it('should allow to reconstruct the shortest path from the nextVertices matrix', () => {
+    const vertexX = new GraphVertex('X');
+    const vertexA = new GraphVertex('A');
+    const vertexM = new GraphVertex('M');
+    const vertexB = new GraphVertex('B');
+    const vertexY = new GraphVertex('Y');
+
+    const edgeXA = new GraphEdge(vertexX, vertexA, 1);
+    const edgeAM = new GraphEdge(vertexA, vertexM, 1);
+    const edgeMB = new GraphEdge(vertexM, vertexB, 1);
+    const edgeBY = new GraphEdge(vertexB, vertexY, 1);
+
+    const graph = new Graph(true);
+
+    graph
+      .addEdge(edgeXA)
+      .addEdge(edgeAM)
+      .addEdge(edgeMB)
+      .addEdge(edgeBY);
+
+    const { distances, nextVertices } = floydWarshall(graph);
+
+    const verticesIndices = graph.getVerticesIndices();
+
+    expect(distances[verticesIndices.X][verticesIndices.Y]).toBe(4);
+
+    // Walk the nextVertices matrix from X all the way to Y to restore the path.
+    const path = [vertexX];
+    while (path[path.length - 1] !== vertexY) {
+      const currentVertexIndex = verticesIndices[path[path.length - 1].getKey()];
+      path.push(nextVertices[currentVertexIndex][verticesIndices.Y]);
+    }
+
+    expect(path.map((vertex) => vertex.getKey())).toEqual(['X', 'A', 'M', 'B', 'Y']);
   });
 });

--- a/src/algorithms/graph/floyd-warshall/floydWarshall.js
+++ b/src/algorithms/graph/floyd-warshall/floydWarshall.js
@@ -6,8 +6,8 @@ export default function floydWarshall(graph) {
   // Get all graph vertices.
   const vertices = graph.getAllVertices();
 
-  // Init previous vertices matrix with nulls meaning that there are no
-  // previous vertices exist that will give us shortest path.
+  // Init next vertices matrix with nulls meaning that there are no
+  // next vertices exist that will give us shortest path.
   const nextVertices = Array(vertices.length).fill(null).map(() => {
     return Array(vertices.length).fill(null);
   });
@@ -19,7 +19,7 @@ export default function floydWarshall(graph) {
   });
 
   // Init distance matrix with the distance we already now (from existing edges).
-  // And also init previous vertices from the edges.
+  // And also init next vertices from the edges.
   vertices.forEach((startVertex, startIndex) => {
     vertices.forEach((endVertex, endIndex) => {
       if (startVertex === endVertex) {
@@ -31,9 +31,10 @@ export default function floydWarshall(graph) {
 
         if (edge) {
           // There is an edge from vertex with startIndex to vertex with endIndex.
-          // Save distance and previous vertex.
+          // Save distance and the next vertex on the way from start to end. For
+          // the direct edge the next vertex is the end vertex itself.
           distances[startIndex][endIndex] = edge.weight;
-          nextVertices[startIndex][endIndex] = startVertex;
+          nextVertices[startIndex][endIndex] = endVertex;
         } else {
           distances[startIndex][endIndex] = Infinity;
         }
@@ -53,14 +54,17 @@ export default function floydWarshall(graph) {
       vertices.forEach((endVertex, endIndex) => {
         // Compare existing distance from startVertex to endVertex, with distance
         // from startVertex to endVertex but via middleVertex.
-        // Save the shortest distance and previous vertex that allows
+        // Save the shortest distance and the next vertex that allows
         // us to have this shortest distance.
         const distViaMiddle = distances[startIndex][middleIndex] + distances[middleIndex][endIndex];
 
         if (distances[startIndex][endIndex] > distViaMiddle) {
-          // We've found a shortest pass via middle vertex.
+          // We've found a shortest pass via middle vertex. Since the shortest
+          // path now goes through the middle vertex, the first step from the
+          // start vertex is the same as the first step on the way from the
+          // start vertex to the middle one.
           distances[startIndex][endIndex] = distViaMiddle;
-          nextVertices[startIndex][endIndex] = middleVertex;
+          nextVertices[startIndex][endIndex] = nextVertices[startIndex][middleIndex];
         }
       });
     });

--- a/src/algorithms/graph/kruskal/__test__/kruskal.test.js
+++ b/src/algorithms/graph/kruskal/__test__/kruskal.test.js
@@ -88,4 +88,32 @@ describe('kruskal', () => {
     expect(minimumSpanningTree.getAllEdges().length).toBe(graph.getAllVertices().length - 1);
     expect(minimumSpanningTree.toString()).toBe('A,B,C,D');
   });
+
+  it('should not modify the original graph', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+
+    const edgeAB = new GraphEdge(vertexA, vertexB, 1);
+    const edgeBC = new GraphEdge(vertexB, vertexC, 2);
+    const edgeAC = new GraphEdge(vertexA, vertexC, 3);
+
+    const graph = new Graph();
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeAC);
+
+    // Remember the original vertex degrees. The spanning tree is built from
+    // the edge instances that are shared with the original graph so building
+    // it must not attach any duplicate edges to the original graph vertices.
+    const degreesBefore = graph.getAllVertices().map((vertex) => vertex.getDegree());
+
+    kruskal(graph);
+
+    const degreesAfter = graph.getAllVertices().map((vertex) => vertex.getDegree());
+
+    expect(degreesAfter).toEqual(degreesBefore);
+  });
 });

--- a/src/algorithms/graph/prim/__test__/prim.test.js
+++ b/src/algorithms/graph/prim/__test__/prim.test.js
@@ -88,4 +88,29 @@ describe('prim', () => {
     expect(minimumSpanningTree.getAllEdges().length).toBe(graph.getAllVertices().length - 1);
     expect(minimumSpanningTree.toString()).toBe('A,B,C,D');
   });
+
+  it('should fire an error for disconnected graph', () => {
+    function applyPrimToDisconnectedGraph() {
+      const vertexA = new GraphVertex('A');
+      const vertexB = new GraphVertex('B');
+      const vertexC = new GraphVertex('C');
+      const vertexD = new GraphVertex('D');
+
+      // Two disconnected components: "A - B" and "C - D".
+      const edgeAB = new GraphEdge(vertexA, vertexB, 1);
+      const edgeCD = new GraphEdge(vertexC, vertexD, 2);
+
+      const graph = new Graph();
+
+      graph
+        .addEdge(edgeAB)
+        .addEdge(edgeCD);
+
+      prim(graph);
+    }
+
+    expect(applyPrimToDisconnectedGraph).toThrow(
+      'Prim\'s algorithm works only for connected graphs',
+    );
+  });
 });

--- a/src/algorithms/graph/prim/prim.js
+++ b/src/algorithms/graph/prim/prim.js
@@ -69,5 +69,11 @@ export default function prim(graph) {
     }
   }
 
+  // If some of the vertices haven't been visited then the graph is disconnected
+  // and it is not possible to build the spanning tree that includes all vertices.
+  if (Object.keys(visitedVertices).length !== graph.getAllVertices().length) {
+    throw new Error('Prim\'s algorithm works only for connected graphs');
+  }
+
   return minimumSpanningTree;
 }

--- a/src/algorithms/graph/strongly-connected-components/__test__/stronglyConnectedComponents.test.js
+++ b/src/algorithms/graph/strongly-connected-components/__test__/stronglyConnectedComponents.test.js
@@ -126,4 +126,30 @@ describe('stronglyConnectedComponents', () => {
     expect(components[0].map((vertex) => vertex.getKey()).sort()).toEqual(['A', 'B', 'C']);
     expect(components[1].map((vertex) => vertex.getKey())).toEqual(['D']);
   });
+
+  it('should not leave the graph reversed after the algorithm run', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+
+    const edgeAB = new GraphEdge(vertexA, vertexB);
+    const edgeBC = new GraphEdge(vertexB, vertexC);
+    const edgeCA = new GraphEdge(vertexC, vertexA);
+
+    const graph = new Graph(true);
+
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCA);
+
+    stronglyConnectedComponents(graph);
+
+    // All the edges must keep their original directions.
+    expect(graph.findEdge(vertexA, vertexB)).toBe(edgeAB);
+    expect(graph.findEdge(vertexB, vertexA)).toBeNull();
+    expect(edgeAB.startVertex).toBe(vertexA);
+    expect(edgeAB.endVertex).toBe(vertexB);
+    expect(edgeAB.getKey()).toBe('A_B');
+  });
 });

--- a/src/algorithms/graph/strongly-connected-components/stronglyConnectedComponents.js
+++ b/src/algorithms/graph/strongly-connected-components/stronglyConnectedComponents.js
@@ -129,5 +129,11 @@ export default function stronglyConnectedComponents(graph) {
   graph.reverse();
 
   // Do DFS once again on reversed graph.
-  return getSCCSets(graph, verticesByFinishTime);
+  const stronglyConnectedComponentsSets = getSCCSets(graph, verticesByFinishTime);
+
+  // Reverse the graph one more time to restore its original edge directions
+  // since the graph was reversed only for the internal needs of the algorithm.
+  graph.reverse();
+
+  return stronglyConnectedComponentsSets;
 }

--- a/src/algorithms/graph/topological-sorting/README.md
+++ b/src/algorithms/graph/topological-sorting/README.md
@@ -44,10 +44,10 @@ example, when washing clothes, the washing machine must finish
 before we put the clothes in the dryer). Then, a topological sort 
 gives an order in which to perform the jobs.
 
-Other application is **dependency resolution**. Each vertex is a package
-and each edge is a dependency of package `a` on package 'b'. Then topological
-sorting will provide a sequence of installing dependencies in a way that every
-next dependency has its dependent packages to be installed in prior.
+Another application is **dependency resolution**. Each vertex is a package
+and each edge is a dependency of package `a` on package `b`. Then topological
+sorting will provide an order of installing the packages in which every
+package gets installed only after all of its dependencies are installed.
 
 ## References
 

--- a/src/algorithms/graph/travelling-salesman/__test__/bfTravellingSalesman.test.js
+++ b/src/algorithms/graph/travelling-salesman/__test__/bfTravellingSalesman.test.js
@@ -48,4 +48,72 @@ describe('bfTravellingSalesman', () => {
     expect(salesmanPath[2].getKey()).toEqual(vertexD.getKey());
     expect(salesmanPath[3].getKey()).toEqual(vertexC.getKey());
   });
+
+  it('should take the weight of the closing edge into account', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+
+    const edgeAB = new GraphEdge(vertexA, vertexB, 1);
+    const edgeBC = new GraphEdge(vertexB, vertexC, 1);
+    const edgeCD = new GraphEdge(vertexC, vertexD, 1);
+    const edgeDA = new GraphEdge(vertexD, vertexA, 100);
+    const edgeAC = new GraphEdge(vertexA, vertexC, 2);
+    const edgeBD = new GraphEdge(vertexB, vertexD, 2);
+
+    const graph = new Graph();
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCD)
+      .addEdge(edgeDA)
+      .addEdge(edgeAC)
+      .addEdge(edgeBD);
+
+    const salesmanPath = bfTravellingSalesman(graph);
+
+    // The tour must visit all four vertices exactly once.
+    expect(salesmanPath.length).toBe(4);
+    expect(
+      salesmanPath.map((vertex) => vertex.getKey()).sort(),
+    ).toEqual(['A', 'B', 'C', 'D']);
+
+    // Calculate the weight of the whole tour including the closing edge that
+    // leads from the last tour vertex back to the first one. The optimal tour
+    // here is "A - B - D - C - A" (or its rotation/reflection) of weight 6.
+    // The tour "A - B - C - D - A" of weight 103 must not be chosen even
+    // though its path weight without the closing edge is smaller.
+    let tourWeight = 0;
+    for (let vertexIndex = 0; vertexIndex < salesmanPath.length; vertexIndex += 1) {
+      const fromVertex = salesmanPath[vertexIndex];
+      const toVertex = salesmanPath[(vertexIndex + 1) % salesmanPath.length];
+      tourWeight += graph.findEdge(fromVertex, toVertex).weight;
+    }
+
+    expect(tourWeight).toBe(6);
+  });
+
+  it('should return an empty path if graph has no Hamiltonian cycle', () => {
+    const vertexA = new GraphVertex('A');
+    const vertexB = new GraphVertex('B');
+    const vertexC = new GraphVertex('C');
+    const vertexD = new GraphVertex('D');
+
+    // Triangle "A - B - C" with pendant vertex D. There is no way to visit
+    // all four vertices exactly once and get back to the start vertex.
+    const edgeAB = new GraphEdge(vertexA, vertexB, 1);
+    const edgeBC = new GraphEdge(vertexB, vertexC, 1);
+    const edgeCA = new GraphEdge(vertexC, vertexA, 1);
+    const edgeCD = new GraphEdge(vertexC, vertexD, 1);
+
+    const graph = new Graph();
+    graph
+      .addEdge(edgeAB)
+      .addEdge(edgeBC)
+      .addEdge(edgeCA)
+      .addEdge(edgeCD);
+
+    expect(bfTravellingSalesman(graph)).toEqual([]);
+  });
 });

--- a/src/algorithms/graph/travelling-salesman/bfTravellingSalesman.js
+++ b/src/algorithms/graph/travelling-salesman/bfTravellingSalesman.js
@@ -49,9 +49,10 @@ function findAllPaths(startVertex, paths = [], path = []) {
 function getCycleWeight(adjacencyMatrix, verticesIndices, cycle) {
   let weight = 0;
 
-  for (let cycleIndex = 1; cycleIndex < cycle.length; cycleIndex += 1) {
-    const fromVertex = cycle[cycleIndex - 1];
-    const toVertex = cycle[cycleIndex];
+  for (let cycleIndex = 0; cycleIndex < cycle.length; cycleIndex += 1) {
+    const fromVertex = cycle[cycleIndex];
+    // Link the last cycle vertex back to the first one to close the cycle.
+    const toVertex = cycle[(cycleIndex + 1) % cycle.length];
     const fromVertexIndex = verticesIndices[fromVertex.getKey()];
     const toVertexIndex = verticesIndices[toVertex.getKey()];
     weight += adjacencyMatrix[fromVertexIndex][toVertexIndex];
@@ -74,13 +75,16 @@ export default function bfTravellingSalesman(graph) {
   // Generate all possible paths from startVertex.
   const allPossiblePaths = findAllPaths(startVertex);
 
-  // Filter out paths that are not cycles.
+  // Filter out paths that are not cycles. The salesman tour must visit every
+  // graph vertex exactly once and it must be possible to get back to the
+  // start vertex from the last vertex of the path.
   const allPossibleCycles = allPossiblePaths.filter((path) => {
     /** @var {GraphVertex} */
     const lastVertex = path[path.length - 1];
     const lastVertexNeighbors = lastVertex.getNeighbors();
 
-    return lastVertexNeighbors.includes(startVertex);
+    return path.length === graph.getAllVertices().length
+      && lastVertexNeighbors.includes(startVertex);
   });
 
   // Go through all possible cycles and pick the one with minimum overall tour weight.

--- a/src/algorithms/math/binary-floating-point/__tests__/bitsToFloat.test.js
+++ b/src/algorithms/math/binary-floating-point/__tests__/bitsToFloat.test.js
@@ -30,3 +30,26 @@ describe('bitsToFloat64', () => {
     }
   });
 });
+
+describe('bitsToFloat special cases', () => {
+  const binaryToBits = (binary) => binary.split('').map((bitString) => parseInt(bitString, 10));
+
+  it('should convert all-zero bits to zero', () => {
+    expect(bitsToFloat16(binaryToBits('0000000000000000'))).toBe(0);
+    expect(bitsToFloat32(binaryToBits('00000000000000000000000000000000'))).toBe(0);
+  });
+
+  it('should convert subnormal numbers exactly', () => {
+    // The smallest positive subnormal half-precision number: 2^(-14) * 2^(-10) = 2^(-24).
+    expect(bitsToFloat16(binaryToBits('0000000000000001'))).toBe(2 ** -24);
+    // A subnormal number with several fraction bits set: 2^(-14) * (2^(-1) + 2^(-2)).
+    expect(bitsToFloat16(binaryToBits('0000001100000000'))).toBe((2 ** -14) * 0.75);
+  });
+
+  it('should convert all-ones exponent to Infinity or NaN', () => {
+    expect(bitsToFloat16(binaryToBits('0111110000000000'))).toBe(Infinity);
+    expect(bitsToFloat16(binaryToBits('1111110000000000'))).toBe(-Infinity);
+    expect(bitsToFloat16(binaryToBits('0111110000000001'))).toBe(NaN);
+    expect(bitsToFloat32(binaryToBits('01111111100000000000000000000000'))).toBe(Infinity);
+  });
+});

--- a/src/algorithms/math/binary-floating-point/bitsToFloat.js
+++ b/src/algorithms/math/binary-floating-point/bitsToFloat.js
@@ -84,7 +84,21 @@ function bitsToFloat(bits, precisionConfig) {
     0,
   );
 
-  // Putting all parts together to calculate the final number.
+  // All-zeros exponent means that the number is zero (if the fraction is zero
+  // as well) or a subnormal number. Subnormal numbers use the exponent
+  // of (1 - bias) and don't have the implicit leading 1 in the fraction.
+  if (exponentUnbiased === 0) {
+    return sign * (2 ** (1 - exponentBias)) * fraction;
+  }
+
+  // All-ones exponent encodes the special values:
+  // Infinity (if the fraction is zero) and NaN (otherwise).
+  if (exponentUnbiased === (2 ** exponentBitsCount) - 1) {
+    return fraction === 0 ? sign * Infinity : NaN;
+  }
+
+  // Putting all parts together to calculate the final normalized number
+  // (with the implicit leading 1 in the fraction).
   return sign * (2 ** exponent) * (1 + fraction);
 }
 

--- a/src/algorithms/math/bits/README.md
+++ b/src/algorithms/math/bits/README.md
@@ -206,7 +206,7 @@ time and see if shifted number is bigger than the input number.
 ```
 5 = 0b0101
 Count of valuable bits is: 3
-When we shift 1 four times it will become bigger than 5.
+When we shift 1 three times it will become bigger than 5.
 ```
 
 > See [bitLength.js](bitLength.js) for further details.

--- a/src/algorithms/math/bits/__test__/bitLength.test.js
+++ b/src/algorithms/math/bits/__test__/bitLength.test.js
@@ -11,4 +11,9 @@ describe('bitLength', () => {
     expect(bitLength(0b11110101)).toBe(8);
     expect(bitLength(0b00011110101)).toBe(8);
   });
+
+  it('should calculate number of bits for numbers that are 31 bits long or more', () => {
+    expect(bitLength(2 ** 30)).toBe(31);
+    expect(bitLength(2 ** 40)).toBe(41);
+  });
 });

--- a/src/algorithms/math/bits/__test__/isPowerOfTwo.test.js
+++ b/src/algorithms/math/bits/__test__/isPowerOfTwo.test.js
@@ -17,4 +17,11 @@ describe('isPowerOfTwo', () => {
     expect(isPowerOfTwo(127)).toBe(false);
     expect(isPowerOfTwo(128)).toBe(true);
   });
+
+  it('should detect that zero and negative numbers are not powers of two', () => {
+    expect(isPowerOfTwo(0)).toBe(false);
+    expect(isPowerOfTwo(-1)).toBe(false);
+    expect(isPowerOfTwo(-2)).toBe(false);
+    expect(isPowerOfTwo(-(2 ** 31))).toBe(false);
+  });
 });

--- a/src/algorithms/math/bits/bitLength.js
+++ b/src/algorithms/math/bits/bitLength.js
@@ -7,7 +7,10 @@
 export default function bitLength(number) {
   let bitsCounter = 0;
 
-  while ((1 << bitsCounter) <= number) {
+  // Use 2 ** bitsCounter instead of (1 << bitsCounter) since the bitwise
+  // shift operator works with 32-bit integers only and would overflow here
+  // for numbers that are 31 bits long or more.
+  while ((2 ** bitsCounter) <= number) {
     bitsCounter += 1;
   }
 

--- a/src/algorithms/math/bits/isPowerOfTwo.js
+++ b/src/algorithms/math/bits/isPowerOfTwo.js
@@ -3,5 +3,12 @@
  * @return bool
  */
 export default function isPowerOfTwo(number) {
+  // 1 (2^0) is the smallest power of two and all powers of two are positive.
+  // Without this check zero (and, for example, the minimal 32-bit signed
+  // integer -2^31) would incorrectly pass the bitwise test below.
+  if (number < 1) {
+    return false;
+  }
+
   return (number & (number - 1)) === 0;
 }

--- a/src/algorithms/math/complex-number/README.md
+++ b/src/algorithms/math/complex-number/README.md
@@ -114,7 +114,7 @@ To multiply complex numbers each part of the first complex number gets multiplie
 by each part of the second complex number:
 
 Just use "FOIL", which stands for "**F**irsts, **O**uters, **I**nners, **L**asts" (
-see [Binomial Multiplication](ttps://www.mathsisfun.com/algebra/polynomials-multiplying.html) for
+see [Binomial Multiplication](https://www.mathsisfun.com/algebra/polynomials-multiplying.html) for
 more details):
 
 ![Complex Multiplication](https://www.mathsisfun.com/algebra/images/foil-complex.svg)
@@ -207,7 +207,7 @@ There is a faster way though.
 In the previous example, what happened on the bottom was interesting:
 
 ```text
-(4 − 5i)(4 + 5i) = 16 + 20i − 20i − 25i
+(4 − 5i)(4 + 5i) = 16 + 20i − 20i − 25i^2
 ```
 
 The middle terms `(20i − 20i)` cancel out! Also `i^2 = −1` so we end up with this:

--- a/src/algorithms/math/euclidean-algorithm/README.md
+++ b/src/algorithms/math/euclidean-algorithm/README.md
@@ -25,6 +25,12 @@ negative integer, e.g., `21 = 5 × 105 + (−2) × 252`.
 The fact that the GCD can always be expressed in this way is
 known as Bézout's identity.
 
+The [extended Euclidean algorithm](extendedEuclideanAlgorithm.js)
+computes these Bézout coefficients `x` and `y` (such that
+`a × x + b × y = gcd(a, b)`) along with the GCD itself. The
+coefficients are useful, for example, for computing modular
+multiplicative inverses.
+
 ![GCD](https://upload.wikimedia.org/wikipedia/commons/3/37/Euclid%27s_algorithm_Book_VII_Proposition_2_3.png)
 
 Euclid's method for finding the greatest common divisor (GCD)

--- a/src/algorithms/math/euclidean-algorithm/__test__/extendedEuclideanAlgorithm.test.js
+++ b/src/algorithms/math/euclidean-algorithm/__test__/extendedEuclideanAlgorithm.test.js
@@ -1,0 +1,35 @@
+import extendedEuclideanAlgorithm from '../extendedEuclideanAlgorithm';
+import euclideanAlgorithm from '../euclideanAlgorithm';
+
+describe('extendedEuclideanAlgorithm', () => {
+  it('should calculate GCD along with Bezout coefficients', () => {
+    expect(extendedEuclideanAlgorithm(0, 0).gcd).toBe(0);
+    expect(extendedEuclideanAlgorithm(2, 0)).toEqual({ gcd: 2, x: 1, y: 0 });
+    expect(extendedEuclideanAlgorithm(0, 2)).toEqual({ gcd: 2, x: 0, y: 1 });
+    expect(extendedEuclideanAlgorithm(252, 105).gcd).toBe(21);
+    expect(extendedEuclideanAlgorithm(105, 252).gcd).toBe(21);
+    expect(extendedEuclideanAlgorithm(17, 5).gcd).toBe(1);
+  });
+
+  it('should satisfy the Bezout identity a * x + b * y = gcd', () => {
+    const testPairs = [
+      [252, 105],
+      [105, 252],
+      [17, 5],
+      [1071, 462],
+      [-252, 105],
+      [252, -105],
+      [-252, -105],
+      [0, 5],
+      [5, 0],
+      [1, 1],
+    ];
+
+    testPairs.forEach(([a, b]) => {
+      const { gcd, x, y } = extendedEuclideanAlgorithm(a, b);
+      expect(a * x + b * y).toBe(gcd);
+      expect(gcd).toBe(euclideanAlgorithm(a, b));
+      expect(gcd).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/algorithms/math/euclidean-algorithm/extendedEuclideanAlgorithm.js
+++ b/src/algorithms/math/euclidean-algorithm/extendedEuclideanAlgorithm.js
@@ -1,0 +1,35 @@
+/**
+ * Extended Euclidean Algorithm.
+ *
+ * Besides the greatest common divisor (GCD) of the numbers `a` and `b` it also
+ * finds the coefficients `x` and `y` of Bézout's identity:
+ *
+ * a * x + b * y = gcd(a, b)
+ *
+ * These coefficients are useful, for example, for computing modular
+ * multiplicative inverses.
+ *
+ * @param {number} a
+ * @param {number} b
+ * @return {{gcd: number, x: number, y: number}}
+ */
+export default function extendedEuclideanAlgorithm(a, b) {
+  if (b === 0) {
+    // gcd(a, 0) = a, and a * 1 + 0 * 0 = a.
+    // Normalize the sign so that the returned GCD is always non-negative.
+    return a < 0 ? { gcd: -a, x: -1, y: 0 } : { gcd: a, x: 1, y: 0 };
+  }
+
+  // Since gcd(a, b) = gcd(b, a % b), find the coefficients (x, y)
+  // for the smaller pair first: b * x + (a % b) * y = gcd.
+  const { gcd, x, y } = extendedEuclideanAlgorithm(b, a % b);
+
+  // In JavaScript `a % b === a - Math.trunc(a / b) * b`. Substituting this
+  // into the identity above and regrouping the terms gives the coefficients
+  // for the original pair: a * y + b * (x - Math.trunc(a / b) * y) = gcd.
+  return {
+    gcd,
+    x: y,
+    y: x - Math.trunc(a / b) * y,
+  };
+}

--- a/src/algorithms/math/euclidean-distance/__tests__/euclideanDistance.test.js
+++ b/src/algorithms/math/euclidean-distance/__tests__/euclideanDistance.test.js
@@ -4,11 +4,16 @@ describe('euclideanDistance', () => {
   it('should calculate euclidean distance between vectors', () => {
     expect(euclideanDistance([[1]], [[2]])).toEqual(1);
     expect(euclideanDistance([[2]], [[1]])).toEqual(1);
-    expect(euclideanDistance([[5, 8]], [[7, 3]])).toEqual(5.39);
-    expect(euclideanDistance([[5], [8]], [[7], [3]])).toEqual(5.39);
-    expect(euclideanDistance([[8, 2, 6]], [[3, 5, 7]])).toEqual(5.92);
-    expect(euclideanDistance([[8], [2], [6]], [[3], [5], [7]])).toEqual(5.92);
-    expect(euclideanDistance([[[8]], [[2]], [[6]]], [[[3]], [[5]], [[7]]])).toEqual(5.92);
+    expect(euclideanDistance([[5, 8]], [[7, 3]])).toBeCloseTo(5.39, 2);
+    expect(euclideanDistance([[5], [8]], [[7], [3]])).toBeCloseTo(5.39, 2);
+    expect(euclideanDistance([[8, 2, 6]], [[3, 5, 7]])).toBeCloseTo(5.92, 2);
+    expect(euclideanDistance([[8], [2], [6]], [[3], [5], [7]])).toBeCloseTo(5.92, 2);
+    expect(euclideanDistance([[[8]], [[2]], [[6]]], [[[3]], [[5]], [[7]]])).toBeCloseTo(5.92, 2);
+  });
+
+  it('should not round the distance', () => {
+    expect(euclideanDistance([[0]], [[0.004]])).toBe(0.004);
+    expect(euclideanDistance([[1, 1]], [[2, 2]])).toBe(Math.sqrt(2));
   });
 
   it('should throw an error in case if two matrices are of different shapes', () => {

--- a/src/algorithms/math/euclidean-distance/euclideanDistance.js
+++ b/src/algorithms/math/euclidean-distance/euclideanDistance.js
@@ -22,7 +22,7 @@ const euclideanDistance = (a, b) => {
     squaresTotal += (aCellValue - bCellValue) ** 2;
   });
 
-  return Number(Math.sqrt(squaresTotal).toFixed(2));
+  return Math.sqrt(squaresTotal);
 };
 
 export default euclideanDistance;

--- a/src/algorithms/math/fast-powering/README.md
+++ b/src/algorithms/math/fast-powering/README.md
@@ -17,16 +17,17 @@ How to find `a` raised to the power `b`?
 We multiply `a` to itself, `b` times. That
 is, `a^b = a * a * a * ... * a` (`b` occurrences of `a`).
 
-This operation will take `O(n)` time since we need to do multiplication operation
-exactly `n` times.
+This operation will take `O(b)` time since we need to do the multiplication
+operation exactly `b - 1` times.
 
 ## Fast Power Algorithm
 
 Can we do better than naive algorithm does? Yes we may solve the task of
-powering in `O(log(n))` time.
+powering in `O(log(b))` time.
 
-The algorithm uses divide and conquer approach to compute power. Currently the
-algorithm work for two positive integers `X` and `Y`.
+The algorithm uses divide and conquer approach to compute power. The
+algorithm works for an integer base `X` and an integer power `Y`
+(negative powers are supported as well).
 
 The idea behind the algorithm is based on the fact that:
 
@@ -40,7 +41,13 @@ For **odd** `Y`:
 
 ```text
 X^Y = X^(Y//2) * X^(Y//2) * X
-where Y//2 is result of division of Y by 2 without reminder.
+where Y//2 is result of division of Y by 2 without remainder.
+```
+
+For **negative** `Y`:
+
+```text
+X^Y = 1 / X^(-Y)
 ```
 
 **For example**
@@ -59,10 +66,10 @@ it by saving it to some intermediate variable to avoid its duplicate calculation
 **Time Complexity**
 
 Since each iteration we split the power by half then we will call function
-recursively `log(n)` times. This the time complexity of the algorithm is reduced to:
+recursively `log(b)` times. Thus the time complexity of the algorithm is reduced to:
 
 ```text
-O(log(n))
+O(log(b))
 ```
 
 ## References

--- a/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
+++ b/src/algorithms/math/fast-powering/__test__/fastPowering.test.js
@@ -20,4 +20,11 @@ describe('fastPowering', () => {
     expect(fastPowering(7, 21)).toBe(558545864083284000);
     expect(fastPowering(100, 9)).toBe(1000000000000000000);
   });
+
+  it('should compute negative powers', () => {
+    expect(fastPowering(2, -1)).toBe(0.5);
+    expect(fastPowering(2, -3)).toBe(0.125);
+    expect(fastPowering(10, -2)).toBe(0.01);
+    expect(fastPowering(-2, -3)).toBe(-0.125);
+  });
 });

--- a/src/algorithms/math/fast-powering/fastPowering.js
+++ b/src/algorithms/math/fast-powering/fastPowering.js
@@ -5,13 +5,19 @@
  * Complexity: log(n)
  *
  * @param {number} base - Number that will be raised to the power.
- * @param {number} power - The power that number will be raised to.
+ * @param {number} power - The power that number will be raised to (may be negative).
  * @return {number}
  */
 export default function fastPowering(base, power) {
   if (power === 0) {
     // Anything that is raised to the power of zero is 1.
     return 1;
+  }
+
+  if (power < 0) {
+    // Raising to the negative power is the same as raising to the positive
+    // power and taking the reciprocal of it: x^(-y) = 1 / x^y.
+    return 1 / fastPowering(base, -power);
   }
 
   if (power % 2 === 0) {

--- a/src/algorithms/math/fibonacci/__test__/fibonacci.test.js
+++ b/src/algorithms/math/fibonacci/__test__/fibonacci.test.js
@@ -2,6 +2,7 @@ import fibonacci from '../fibonacci';
 
 describe('fibonacci', () => {
   it('should calculate fibonacci correctly', () => {
+    expect(fibonacci(0)).toEqual([]);
     expect(fibonacci(1)).toEqual([1]);
     expect(fibonacci(2)).toEqual([1, 1]);
     expect(fibonacci(3)).toEqual([1, 1, 2]);

--- a/src/algorithms/math/fibonacci/__test__/fibonacciNth.test.js
+++ b/src/algorithms/math/fibonacci/__test__/fibonacciNth.test.js
@@ -2,6 +2,7 @@ import fibonacciNth from '../fibonacciNth';
 
 describe('fibonacciNth', () => {
   it('should calculate fibonacci correctly', () => {
+    expect(fibonacciNth(0)).toBe(0);
     expect(fibonacciNth(1)).toBe(1);
     expect(fibonacciNth(2)).toBe(1);
     expect(fibonacciNth(3)).toBe(2);

--- a/src/algorithms/math/fibonacci/fibonacci.js
+++ b/src/algorithms/math/fibonacci/fibonacci.js
@@ -5,6 +5,11 @@
  * @return {number[]}
  */
 export default function fibonacci(n) {
+  // A sequence of zero numbers is an empty array.
+  if (n === 0) {
+    return [];
+  }
+
   const fibSequence = [1];
 
   let currentValue = 1;
@@ -16,7 +21,7 @@ export default function fibonacci(n) {
 
   let iterationsCounter = n - 1;
 
-  while (iterationsCounter) {
+  while (iterationsCounter > 0) {
     currentValue += previousValue;
     previousValue = currentValue - previousValue;
 

--- a/src/algorithms/math/fibonacci/fibonacciNth.js
+++ b/src/algorithms/math/fibonacci/fibonacciNth.js
@@ -8,13 +8,17 @@ export default function fibonacciNth(n) {
   let currentValue = 1;
   let previousValue = 0;
 
+  if (n === 0) {
+    return 0;
+  }
+
   if (n === 1) {
     return 1;
   }
 
   let iterationsCounter = n - 1;
 
-  while (iterationsCounter) {
+  while (iterationsCounter > 0) {
     currentValue += previousValue;
     previousValue = currentValue - previousValue;
 

--- a/src/algorithms/math/fourier-transform/__test__/fastFourierTransform.test.js
+++ b/src/algorithms/math/fourier-transform/__test__/fastFourierTransform.test.js
@@ -13,11 +13,12 @@ function sequencesApproximatelyEqual(sequence1, sequence2, delta) {
   }
 
   for (let numberIndex = 0; numberIndex < sequence1.length; numberIndex += 1) {
-    if (Math.abs(sequence1[numberIndex].re - sequence2[numberIndex].re) > delta) {
-      return false;
-    }
+    const reDiff = Math.abs(sequence1[numberIndex].re - sequence2[numberIndex].re);
+    const imDiff = Math.abs(sequence1[numberIndex].im - sequence2[numberIndex].im);
 
-    if (Math.abs(sequence1[numberIndex].im - sequence2[numberIndex].im) > delta) {
+    // Require the differences to be explicitly small so that NaN values
+    // (for which any comparison is false) make the check fail.
+    if (!(reDiff <= delta) || !(imDiff <= delta)) {
       return false;
     }
   }
@@ -47,9 +48,9 @@ describe('fastFourierTransform', () => {
 
     const expectedOutput = [
       new ComplexNumber({ re: 11, im: 9 }),
-      new ComplexNumber({ re: -10, im: 0 }),
-      new ComplexNumber({ re: 7, im: 3 }),
       new ComplexNumber({ re: -4, im: -4 }),
+      new ComplexNumber({ re: 7, im: 3 }),
+      new ComplexNumber({ re: -10, im: 0 }),
     ];
 
     const output = fastFourierTransform(input);
@@ -75,27 +76,63 @@ describe('fastFourierTransform', () => {
 
     const expectedOutput = [
       new ComplexNumber({ re: -203215.3322151, im: -100242.4827503 }),
-      new ComplexNumber({ re: 99217.0805705, im: 270646.9331932 }),
-      new ComplexNumber({ re: -305990.9040412, im: 68224.8435751 }),
-      new ComplexNumber({ re: -14135.7758282, im: 199223.9878095 }),
-      new ComplexNumber({ re: -306965.6350922, im: 26030.1025439 }),
-      new ComplexNumber({ re: -76477.6755206, im: 40781.9078990 }),
-      new ComplexNumber({ re: -48409.3099088, im: 54674.7959662 }),
-      new ComplexNumber({ re: -329683.0131713, im: 164287.7995937 }),
-      new ComplexNumber({ re: -50485.2048527, im: -330375.0546527 }),
-      new ComplexNumber({ re: 122235.7738708, im: 91091.6398019 }),
-      new ComplexNumber({ re: 47625.8850387, im: 73497.3981523 }),
-      new ComplexNumber({ re: -15619.8231136, im: 80804.8685410 }),
-      new ComplexNumber({ re: 192234.0276101, im: 160833.3072355 }),
-      new ComplexNumber({ re: -96389.4195635, im: 393408.4543872 }),
-      new ComplexNumber({ re: -173449.0825417, im: 146875.7724104 }),
       new ComplexNumber({ re: -179002.5662573, im: 239821.0124341 }),
+      new ComplexNumber({ re: -173449.0825417, im: 146875.7724104 }),
+      new ComplexNumber({ re: -96389.4195635, im: 393408.4543872 }),
+      new ComplexNumber({ re: 192234.0276101, im: 160833.3072355 }),
+      new ComplexNumber({ re: -15619.8231136, im: 80804.8685410 }),
+      new ComplexNumber({ re: 47625.8850387, im: 73497.3981523 }),
+      new ComplexNumber({ re: 122235.7738708, im: 91091.6398019 }),
+      new ComplexNumber({ re: -50485.2048527, im: -330375.0546527 }),
+      new ComplexNumber({ re: -329683.0131713, im: 164287.7995937 }),
+      new ComplexNumber({ re: -48409.3099088, im: 54674.7959662 }),
+      new ComplexNumber({ re: -76477.6755206, im: 40781.9078990 }),
+      new ComplexNumber({ re: -306965.6350922, im: 26030.1025439 }),
+      new ComplexNumber({ re: -14135.7758282, im: 199223.9878095 }),
+      new ComplexNumber({ re: -305990.9040412, im: 68224.8435751 }),
+      new ComplexNumber({ re: 99217.0805705, im: 270646.9331932 }),
     ];
 
     const output = fastFourierTransform(input);
     const invertedOutput = fastFourierTransform(output, true);
 
     expect(sequencesApproximatelyEqual(expectedOutput, output, delta)).toBe(true);
+    expect(sequencesApproximatelyEqual(input, invertedOutput, delta)).toBe(true);
+  });
+
+  it('should follow the same sign convention as the direct fourier transform', () => {
+    // For the real input [1, 2, 3, 4] the standard DFT
+    // (with the e^(-2*pi*i*k*n/N) forward kernel, the same convention
+    // as in discreteFourierTransform.js) gives X = [10, -2+2i, -2, -2-2i].
+    const input = [
+      new ComplexNumber({ re: 1 }),
+      new ComplexNumber({ re: 2 }),
+      new ComplexNumber({ re: 3 }),
+      new ComplexNumber({ re: 4 }),
+    ];
+
+    const expectedOutput = [
+      new ComplexNumber({ re: 10, im: 0 }),
+      new ComplexNumber({ re: -2, im: 2 }),
+      new ComplexNumber({ re: -2, im: 0 }),
+      new ComplexNumber({ re: -2, im: -2 }),
+    ];
+
+    const output = fastFourierTransform(input);
+
+    expect(sequencesApproximatelyEqual(expectedOutput, output, delta)).toBe(true);
+  });
+
+  it('should invert the direct transform back to the original signal', () => {
+    const input = [
+      new ComplexNumber({ re: 1 }),
+      new ComplexNumber({ re: 2 }),
+      new ComplexNumber({ re: 3 }),
+      new ComplexNumber({ re: 4 }),
+    ];
+
+    const invertedOutput = fastFourierTransform(fastFourierTransform(input), true);
+
     expect(sequencesApproximatelyEqual(input, invertedOutput, delta)).toBe(true);
   });
 });

--- a/src/algorithms/math/fourier-transform/fastFourierTransform.js
+++ b/src/algorithms/math/fourier-transform/fastFourierTransform.js
@@ -44,7 +44,9 @@ export default function fastFourierTransform(inputData, inverse = false) {
   }
 
   for (let blockLength = 2; blockLength <= N; blockLength *= 2) {
-    const imaginarySign = inverse ? -1 : 1;
+    // The forward transform uses the e^(-2*pi*i/blockLength) kernel
+    // and the inverse transform uses the e^(2*pi*i/blockLength) one.
+    const imaginarySign = inverse ? 1 : -1;
     const phaseStep = new ComplexNumber({
       re: Math.cos((2 * Math.PI) / blockLength),
       im: imaginarySign * Math.sin((2 * Math.PI) / blockLength),
@@ -69,7 +71,7 @@ export default function fastFourierTransform(inputData, inverse = false) {
 
   if (inverse) {
     for (let signalId = 0; signalId < N; signalId += 1) {
-      output[signalId] /= N;
+      output[signalId] = output[signalId].divide(N);
     }
   }
 

--- a/src/algorithms/math/horner-method/README.md
+++ b/src/algorithms/math/horner-method/README.md
@@ -1,6 +1,6 @@
 # Horner's Method
 
-In mathematics, Horner's method (or Horner's scheme) is an algorithm for polynomial evaluation. With this method, it is possible to evaluate a polynomial with only `n` additions and `n` multiplications. Hence, its storage requirements are `n` times the number of bits of `x`.
+In mathematics, Horner's method (or Horner's scheme) is an algorithm for polynomial evaluation. With this method, it is possible to evaluate a polynomial of degree `n` with only `n` additions and `n` multiplications, while using only a constant amount of auxiliary memory.
 
 Horner's method can be based on the following identity:
 
@@ -13,7 +13,7 @@ To solve the right part of the identity above, for a given `x`, we start by iter
 **Using the polynomial:**
 `4 * x^4 + 2 * x^3 + 3 * x^2 + x^1 + 3`, a traditional approach to evaluate it at `x = 2`, could be representing it as an array `[3, 1, 3, 2, 4]` and iterate over it saving each iteration value at an accumulator, such as `acc += pow(x=2, index) * array[index]`. In essence, each power of a number (`pow`) operation is `n-1` multiplications. So, in this scenario, a total of `14` operations would have happened, composed of `4` additions, `5` multiplications, and `5` pows (we're assuming that each power is calculated by repeated multiplication).
 
-Now, **using the same scenario but with Horner's rule**, the polynomial can be re-written as `x * (x * (x * (4 * x + 2) + 3) + 1) + 3`, representing it as `[4, 2, 3, 1, 3]` it is possible to save the first iteration as `acc = arr[0] * (x=2) + arr[1]`, and then finish iterations for `acc *= (x=2) + arr[index]`. In the same scenario but using Horner's rule, a total of `10` operations would have happened, composed of only `4` additions and `4` multiplications.
+Now, **using the same scenario but with Horner's rule**, the polynomial can be re-written as `x * (x * (x * (4 * x + 2) + 3) + 1) + 3`, representing it as `[4, 2, 3, 1, 3]` it is possible to save the first iteration as `acc = arr[0] * (x=2) + arr[1]`, and then finish iterations as `acc = acc * (x=2) + arr[index]`. In the same scenario but using Horner's rule, a total of `8` operations would have happened, composed of only `4` additions and `4` multiplications.
 
 ## References
 

--- a/src/algorithms/math/horner-method/__test__/classicPolynome.test.js
+++ b/src/algorithms/math/horner-method/__test__/classicPolynome.test.js
@@ -11,4 +11,13 @@ describe('classicPolynome', () => {
     expect(classicPolynome([0, 0, 2.77, 1.42, 2.3311], 1.35)).toBe(9.296425000000001);
     expect(classicPolynome([2, 0, 0, 5.757, 5.31412, 12.3213], 3.141)).toBe(697.2731167035034);
   });
+
+  it('should not mutate the coefficients array of the caller', () => {
+    const coefficients = [2, 4, 2, 5];
+
+    expect(classicPolynome(coefficients, 0.75)).toBe(9.59375);
+    // The second call with the same array must give the same result.
+    expect(classicPolynome(coefficients, 0.75)).toBe(9.59375);
+    expect(coefficients).toEqual([2, 4, 2, 5]);
+  });
 });

--- a/src/algorithms/math/horner-method/classicPolynome.js
+++ b/src/algorithms/math/horner-method/classicPolynome.js
@@ -7,7 +7,8 @@
  * @return {number}
  */
 export default function classicPolynome(coefficients, xVal) {
-  return coefficients.reverse().reduce(
+  // Reverse a copy of the coefficients so the caller's array isn't mutated.
+  return [...coefficients].reverse().reduce(
     (accumulator, currentCoefficient, index) => {
       return accumulator + currentCoefficient * (xVal ** index);
     },

--- a/src/algorithms/math/pascal-triangle/README.md
+++ b/src/algorithms/math/pascal-triangle/README.md
@@ -58,6 +58,13 @@ C(lineNumber, i) = C(lineNumber, i - 1) * (lineNumber - i + 1) / i
 So `C(lineNumber, i)` can be calculated 
 from `C(lineNumber, i - 1)` in `O(1)` time.
 
+> **Precision note:** JavaScript numbers are 64-bit floats, so the
+> intermediate product `C(lineNumber, i - 1) * (lineNumber - i + 1)` in the
+> formula above loses integer precision once it exceeds
+> `Number.MAX_SAFE_INTEGER` (`2^53 - 1`). As a result this multiplicative
+> approach returns only approximate entries for the big line numbers (the
+> first failure happens around the line number `55`).
+
 ## References
 
 - [Wikipedia](https://en.wikipedia.org/wiki/Pascal%27s_triangle)

--- a/src/algorithms/math/pascal-triangle/pascalTriangle.js
+++ b/src/algorithms/math/pascal-triangle/pascalTriangle.js
@@ -1,4 +1,9 @@
 /**
+ * Note on precision: the intermediate product in the formula below may exceed
+ * Number.MAX_SAFE_INTEGER (2^53 - 1). When that happens the integer precision
+ * is lost and the returned entries are only approximate. The first line number
+ * for which this happens is around 55.
+ *
  * @param {number} lineNumber - zero based.
  * @return {number[]}
  */

--- a/src/algorithms/math/sieve-of-eratosthenes/README.md
+++ b/src/algorithms/math/sieve-of-eratosthenes/README.md
@@ -13,7 +13,7 @@ It is attributed to Eratosthenes of Cyrene, an ancient Greek mathematician.
 5. Find the first position greater than `p` that is `true` in the array. If there is no such position, stop. Otherwise, let `p` equal this new number (which is the next prime), and repeat from step 4
 
 When the algorithm terminates, the numbers remaining `true` in the array are all 
-the primes below `n`.
+the primes up to (and including) `n`.
 
 An improvement of this algorithm is, in step 4, start marking multiples 
 of `p` from `p * p`, and not from `2 * p`. The reason why this works is because, 

--- a/src/algorithms/math/square-root/__test__/squareRoot.test.js
+++ b/src/algorithms/math/square-root/__test__/squareRoot.test.js
@@ -66,4 +66,12 @@ describe('squareRoot', () => {
     expect(squareRoot(4.5, 10)).toBe(2.1213203436);
     expect(squareRoot(217.534, 10)).toBe(14.7490338667);
   });
+
+  it('should not hang for tolerances beyond the double precision limit', () => {
+    // The tolerances of >= 16 digits are not achievable with the 64-bit floats.
+    // The function must stop improving the approximation at some point
+    // instead of iterating forever.
+    expect(squareRoot(2, 17)).toBeCloseTo(1.4142135623730951, 15);
+    expect(squareRoot(5, 20)).toBeCloseTo(2.23606797749979, 14);
+  });
 });

--- a/src/algorithms/math/square-root/squareRoot.js
+++ b/src/algorithms/math/square-root/squareRoot.js
@@ -20,6 +20,9 @@ export default function squareRoot(number, tolerance = 0) {
   // We will start approximation from value 1.
   let root = 1;
 
+  // The value of the root on the previous approximation step.
+  let previousRoot = null;
+
   // Delta is a desired distance between the number and the square of the root.
   // - if tolerance=0 then delta=1
   // - if tolerance=1 then delta=0.1
@@ -32,7 +35,19 @@ export default function squareRoot(number, tolerance = 0) {
     // Newton's method reduces in this case to the so-called Babylonian method.
     // These methods generally yield approximate results, but can be made arbitrarily
     // precise by increasing the number of calculation steps.
-    root -= ((root ** 2) - number) / (2 * root);
+    const improvedRoot = root - (((root ** 2) - number) / (2 * root));
+
+    // If the approximation stopped improving (it either stays the same or starts
+    // oscillating between two neighboring floating point values) it means that
+    // we've hit the precision limit of the double floating point numbers and the
+    // root can't get any more precise. Stop to avoid an endless loop in case of
+    // a very small tolerance.
+    if (improvedRoot === root || improvedRoot === previousRoot) {
+      break;
+    }
+
+    previousRoot = root;
+    root = improvedRoot;
   }
 
   // Cut off undesired floating digits and return the root value.

--- a/src/algorithms/ml/k-means/README.md
+++ b/src/algorithms/ml/k-means/README.md
@@ -20,7 +20,7 @@ The algorithm is as follows:
 3. Calculate the distance of each data point from each cluster
 4. Assign the cluster label of each data point equal to that of the cluster at its minimum distance
 5. Calculate the centroid of each cluster based on the data points it contains
-6. Repeat each of the above steps until the centroid locations are varying
+6. Repeat each of the above steps until the centroid locations stop varying
 
 Here is a visualization of k-Means clustering for better understanding:
 
@@ -37,4 +37,4 @@ The centroids are moving continuously in order to create better distinction betw
 
 ## References
 
-- [k-Means neighbors algorithm on Wikipedia](https://en.wikipedia.org/wiki/K-means_clustering)
+- [k-means clustering on Wikipedia](https://en.wikipedia.org/wiki/K-means_clustering)

--- a/src/algorithms/ml/k-means/__test__/kMeans.test.js
+++ b/src/algorithms/ml/k-means/__test__/kMeans.test.js
@@ -37,4 +37,15 @@ describe('kMeans', () => {
     const expectedCluster = [1, 1, 0];
     expect(KMeans(dataSet, k)).toEqual(expectedCluster);
   });
+
+  it('should assign valid cluster ids even when some cluster becomes empty', () => {
+    // The first two initial centroids are equal here, so one of the clusters
+    // becomes empty after the first assignment step. The empty cluster must
+    // keep its previous centroid instead of turning into a NaN centroid
+    // (which would make all the points fall into a non-existent cluster -1).
+    const classes = KMeans([[0], [0], [10]], 2);
+
+    expect(classes).not.toContain(-1);
+    expect(classes).toEqual([1, 1, 0]);
+  });
 });

--- a/src/algorithms/ml/k-means/kMeans.js
+++ b/src/algorithms/ml/k-means/kMeans.js
@@ -58,8 +58,8 @@ export default function KMeans(
 
     // Recalculate cluster centroid values via all dimensions of the points under it.
     for (let clusterIndex = 0; clusterIndex < k; clusterIndex += 1) {
-      // Reset cluster center coordinates since we need to recalculate them.
-      clusterCenters[clusterIndex] = Array(dataDim).fill(0);
+      // Sum of the coordinates of all the points assigned to the current cluster.
+      const centroidSums = Array(dataDim).fill(0);
       let clusterSize = 0;
       for (let dataIndex = 0; dataIndex < data.length; dataIndex += 1) {
         if (classes[dataIndex] === clusterIndex) {
@@ -67,15 +67,17 @@ export default function KMeans(
           clusterSize += 1;
           for (let dimensionIndex = 0; dimensionIndex < dataDim; dimensionIndex += 1) {
             // Add data point coordinates to the cluster center coordinates.
-            clusterCenters[clusterIndex][dimensionIndex] += data[dataIndex][dimensionIndex];
+            centroidSums[dimensionIndex] += data[dataIndex][dimensionIndex];
           }
         }
       }
-      // Calculate the average for each cluster center coordinate.
-      for (let dimensionIndex = 0; dimensionIndex < dataDim; dimensionIndex += 1) {
-        clusterCenters[clusterIndex][dimensionIndex] = parseFloat(Number(
-          clusterCenters[clusterIndex][dimensionIndex] / clusterSize,
-        ).toFixed(2));
+      // If the cluster is empty we keep its previous centroid.
+      // Otherwise averaging would result in a 0/0 = NaN centroid.
+      if (clusterSize > 0) {
+        // Calculate the average for each cluster center coordinate.
+        clusterCenters[clusterIndex] = centroidSums.map(
+          (coordinatesSum) => coordinatesSum / clusterSize,
+        );
       }
     }
   }

--- a/src/algorithms/search/interpolation-search/README.md
+++ b/src/algorithms/search/interpolation-search/README.md
@@ -22,7 +22,7 @@ To find the position to be searched, it uses following formula:
 // The idea of formula is to return higher value of pos
 // when element to be searched is closer to arr[hi]. And
 // smaller value when closer to arr[lo]
-pos = lo + ((x - arr[lo]) * (hi - lo) / (arr[hi] - arr[Lo]))
+pos = lo + ((x - arr[lo]) * (hi - lo) / (arr[hi] - arr[lo]))
 
 arr[] - Array where elements need to be searched
 x - Element to be searched
@@ -32,7 +32,7 @@ hi - Ending index in arr[]
 
 ## Complexity
 
-**Time complexity**: `O(log(log(n))`
+**Time complexity**: `O(log(log(n)))`
 
 ## References
 

--- a/src/algorithms/search/interpolation-search/__test__/interpolationSearch.test.js
+++ b/src/algorithms/search/interpolation-search/__test__/interpolationSearch.test.js
@@ -21,4 +21,18 @@ describe('interpolationSearch', () => {
     expect(interpolationSearch([1, 2, 3, 700, 800, 1200, 1300, 1400, 19000], 800)).toBe(4);
     expect(interpolationSearch([0, 10, 11, 12, 13, 14, 15], 10)).toBe(1);
   });
+
+  it('should not hang when seeking element above the maximum array value', () => {
+    // Used to infinitely loop since the interpolated index was landing
+    // out of array bounds and the search range was never shrinking.
+    expect(interpolationSearch([1, 2, 3, 4, 5, 6, 7, 8, 9], 10)).toBe(-1);
+    expect(interpolationSearch([1, 2, 3, 4, 5, 6, 7, 8, 9], 0)).toBe(-1);
+  });
+
+  it('should not hang when searching in non-uniformly distributed array', () => {
+    // Used to infinitely loop since the search range was never shrinking.
+    expect(interpolationSearch([0, 5, 10, 17, 18], 16)).toBe(-1);
+    expect(interpolationSearch([0, 5, 10, 17, 18], 17)).toBe(3);
+    expect(interpolationSearch([0, 5, 10, 17, 18], 5)).toBe(1);
+  });
 });

--- a/src/algorithms/search/interpolation-search/interpolationSearch.js
+++ b/src/algorithms/search/interpolation-search/interpolationSearch.js
@@ -10,16 +10,18 @@ export default function interpolationSearch(sortedArray, seekElement) {
   let rightIndex = sortedArray.length - 1;
 
   while (leftIndex <= rightIndex) {
+    // If the seek element is outside of the current range boundaries then
+    // there is no such element in the array since the array is sorted and
+    // all its remaining values lie in [sortedArray[leftIndex], sortedArray[rightIndex]].
+    // This check also guarantees that the interpolated middle index (see below)
+    // always lands inside the [leftIndex, rightIndex] range.
+    if (seekElement < sortedArray[leftIndex] || seekElement > sortedArray[rightIndex]) {
+      return -1;
+    }
+
     const rangeDelta = sortedArray[rightIndex] - sortedArray[leftIndex];
     const indexDelta = rightIndex - leftIndex;
     const valueDelta = seekElement - sortedArray[leftIndex];
-
-    // If valueDelta is less then zero it means that there is no seek element
-    // exists in array since the lowest element from the range is already higher
-    // then seek element.
-    if (valueDelta < 0) {
-      return -1;
-    }
 
     // If range delta is zero then subarray contains all the same numbers
     // and thus there is nothing to search for unless this range is all
@@ -30,8 +32,10 @@ export default function interpolationSearch(sortedArray, seekElement) {
       return sortedArray[leftIndex] === seekElement ? leftIndex : -1;
     }
 
-    // Do interpolation of the middle index.
-    const middleIndex = leftIndex + Math.floor((valueDelta * indexDelta) / rangeDelta);
+    // Do interpolation of the middle index. Clamp it into the current
+    // [leftIndex, rightIndex] range to protect against any rounding issues.
+    const interpolatedIndex = leftIndex + Math.floor((valueDelta * indexDelta) / rangeDelta);
+    const middleIndex = Math.max(leftIndex, Math.min(rightIndex, interpolatedIndex));
 
     // If we've found the element just return its position.
     if (sortedArray[middleIndex] === seekElement) {
@@ -39,6 +43,9 @@ export default function interpolationSearch(sortedArray, seekElement) {
     }
 
     // Decide which half to choose for seeking next: left or right one.
+    // Since the middle element gets excluded from the range, the search
+    // range strictly shrinks on every iteration and the loop is guaranteed
+    // to terminate.
     if (sortedArray[middleIndex] < seekElement) {
       // Go to the right half of the array.
       leftIndex = middleIndex + 1;

--- a/src/algorithms/sets/combination-sum/README.md
+++ b/src/algorithms/sets/combination-sum/README.md
@@ -2,7 +2,7 @@
 
 Given a **set** of candidate numbers (`candidates`) **(without duplicates)** and 
 a target number (`target`), find all unique combinations in `candidates` where 
-the candidate numbers sums to `target`.
+the candidate numbers sum to `target`.
 
 The **same** repeated number may be chosen from `candidates` unlimited number 
 of times.

--- a/src/algorithms/sets/combinations/README.md
+++ b/src/algorithms/sets/combinations/README.md
@@ -7,7 +7,7 @@ When the order **does** matter it is a **Permutation**.
 **"My fruit salad is a combination of apples, grapes and bananas"**
 We don't care what order the fruits are in, they could also be
 "bananas, grapes and apples" or "grapes, apples and bananas",
-its the same fruit salad.
+it's the same fruit salad.
 
 ## Combinations without repetitions
 

--- a/src/algorithms/sets/knapsack-problem/Knapsack.js
+++ b/src/algorithms/sets/knapsack-problem/Knapsack.js
@@ -115,34 +115,24 @@ export default class Knapsack {
       }
     }
 
-    // Now let's trace back the knapsack matrix to see what items we're going to add
-    // to the knapsack.
+    // Now let's trace the knapsack matrix back to see what items we're going
+    // to add to the knapsack. If the max value in the current weight column
+    // differs from the max value for the previous item in the same column then
+    // it means that the current item HAS been added to the knapsack. In this
+    // case we need to subtract its weight and proceed to the reduced knapsack.
+    // Otherwise the current item has been skipped.
     let itemIndex = this.possibleItems.length - 1;
     let weightIndex = this.weightLimit;
 
-    while (itemIndex > 0) {
+    while (itemIndex >= 0) {
       const currentItem = this.possibleItems[itemIndex];
-      const prevItem = this.possibleItems[itemIndex - 1];
 
-      // Check if matrix value came from top (from previous item).
-      // In this case this would mean that we need to include previous item
-      // to the list of selected items.
-      if (
-        knapsackMatrix[itemIndex][weightIndex]
-        && knapsackMatrix[itemIndex][weightIndex] === knapsackMatrix[itemIndex - 1][weightIndex]
-      ) {
-        // Check if there are several items with the same weight but with the different values.
-        // We need to add highest item in the matrix that is possible to get the highest value.
-        const prevSumValue = knapsackMatrix[itemIndex - 1][weightIndex];
-        const prevPrevSumValue = knapsackMatrix[itemIndex - 2][weightIndex];
-        if (
-          !prevSumValue
-          || (prevSumValue && prevPrevSumValue !== prevSumValue)
-        ) {
-          this.selectedItems.push(prevItem);
-        }
-      } else if (knapsackMatrix[itemIndex - 1][weightIndex - currentItem.weight]) {
-        this.selectedItems.push(prevItem);
+      // For the very first item there is no previous row in the matrix, thus
+      // we're comparing its max value with zero (the empty knapsack value).
+      const prevItemMaxValue = itemIndex > 0 ? knapsackMatrix[itemIndex - 1][weightIndex] : 0;
+
+      if (knapsackMatrix[itemIndex][weightIndex] !== prevItemMaxValue) {
+        this.selectedItems.push(currentItem);
         weightIndex -= currentItem.weight;
       }
 
@@ -164,17 +154,21 @@ export default class Knapsack {
         const availableWeight = this.weightLimit - this.totalWeight;
         const maxPossibleItemsCount = Math.floor(availableWeight / currentItem.weight);
 
-        if (maxPossibleItemsCount > currentItem.itemsInStock) {
-          // If we have more items in stock then it is allowed to add
-          // let's add the maximum allowed number of them.
-          currentItem.quantity = currentItem.itemsInStock;
-        } else if (maxPossibleItemsCount) {
-          // In case if we don't have specified number of items in stock
-          // let's add only items we have in stock.
-          currentItem.quantity = maxPossibleItemsCount;
-        }
+        // If the item doesn't fit into the remaining knapsack space at all
+        // (maxPossibleItemsCount is zero) then we must not add it.
+        if (maxPossibleItemsCount) {
+          if (maxPossibleItemsCount > currentItem.itemsInStock) {
+            // If we have more items in stock then it is allowed to add
+            // let's add the maximum allowed number of them.
+            currentItem.quantity = currentItem.itemsInStock;
+          } else {
+            // In case if we don't have specified number of items in stock
+            // let's add only items we have in stock.
+            currentItem.quantity = maxPossibleItemsCount;
+          }
 
-        this.selectedItems.push(currentItem);
+          this.selectedItems.push(currentItem);
+        }
       }
     }
   }

--- a/src/algorithms/sets/knapsack-problem/__test__/Knapsack.test.js
+++ b/src/algorithms/sets/knapsack-problem/__test__/Knapsack.test.js
@@ -87,6 +87,41 @@ describe('Knapsack', () => {
     expect(knapsack.selectedItems[2].toString()).toBe('v7 w1 x 1');
   });
 
+  it('should solve 0/1 knapsack problem with a single item that fits', () => {
+    const possibleKnapsackItems = [
+      new KnapsackItem({ value: 5, weight: 2 }),
+    ];
+
+    const maxKnapsackWeight = 3;
+
+    const knapsack = new Knapsack(possibleKnapsackItems, maxKnapsackWeight);
+
+    knapsack.solveZeroOneKnapsackProblem();
+
+    expect(knapsack.totalValue).toBe(5);
+    expect(knapsack.totalWeight).toBe(2);
+    expect(knapsack.selectedItems.length).toBe(1);
+    expect(knapsack.selectedItems[0].toString()).toBe('v5 w2 x 1');
+  });
+
+  it('should solve 0/1 knapsack problem when the best item weighs exactly the limit', () => {
+    const possibleKnapsackItems = [
+      new KnapsackItem({ value: 1, weight: 1 }),
+      new KnapsackItem({ value: 10, weight: 5 }),
+    ];
+
+    const maxKnapsackWeight = 5;
+
+    const knapsack = new Knapsack(possibleKnapsackItems, maxKnapsackWeight);
+
+    knapsack.solveZeroOneKnapsackProblem();
+
+    expect(knapsack.totalValue).toBe(10);
+    expect(knapsack.totalWeight).toBe(5);
+    expect(knapsack.selectedItems.length).toBe(1);
+    expect(knapsack.selectedItems[0].toString()).toBe('v10 w5 x 1');
+  });
+
   it('should solve unbound knapsack problem', () => {
     const possibleKnapsackItems = [
       new KnapsackItem({ value: 84, weight: 7 }), // v/w ratio is 12
@@ -158,5 +193,25 @@ describe('Knapsack', () => {
     expect(knapsack.selectedItems[2].toString()).toBe('v10 w1 x 6');
     expect(knapsack.selectedItems[3].toString()).toBe('v12 w3 x 1');
     expect(knapsack.selectedItems[4].toString()).toBe('v5 w2 x 2');
+  });
+
+  it('should not exceed the weight limit in unbound knapsack problem', () => {
+    const possibleKnapsackItems = [
+      new KnapsackItem({ value: 10, weight: 5 }), // v/w ratio is 2
+      new KnapsackItem({ value: 9, weight: 4 }), // v/w ratio is 2.25
+    ];
+
+    const maxKnapsackWeight = 5;
+
+    const knapsack = new Knapsack(possibleKnapsackItems, maxKnapsackWeight);
+
+    knapsack.solveUnboundedKnapsackProblem();
+
+    // The v9 item (higher value per weight unit) is added first and after
+    // that the v10 item doesn't fit anymore and thus must not be added.
+    expect(knapsack.totalValue).toBe(9);
+    expect(knapsack.totalWeight).toBe(4);
+    expect(knapsack.selectedItems.length).toBe(1);
+    expect(knapsack.selectedItems[0].toString()).toBe('v9 w4 x 1');
   });
 });

--- a/src/algorithms/sets/maximum-subarray/README.md
+++ b/src/algorithms/sets/maximum-subarray/README.md
@@ -18,7 +18,7 @@ with the largest sum is `4, −1, 2, 1`, with sum `6`.
 ## Solutions
 
 - Brute Force solution `O(n^2)`: [bfMaximumSubarray.js](./bfMaximumSubarray.js)
-- Divide and Conquer solution `O(n^2)`: [dcMaximumSubarraySum.js](./dcMaximumSubarraySum.js)
+- Recursive (pick / don't pick) solution `O(n^2)`, often referred to as "Divide and Conquer": [dcMaximumSubarraySum.js](./dcMaximumSubarraySum.js)
 - Dynamic Programming solution `O(n)`: [dpMaximumSubarray.js](./dpMaximumSubarray.js)
 
 ## References

--- a/src/algorithms/sets/maximum-subarray/dcMaximumSubarraySum.js
+++ b/src/algorithms/sets/maximum-subarray/dcMaximumSubarraySum.js
@@ -1,9 +1,12 @@
 /**
- * Divide and Conquer solution.
+ * Recursive (pick / don't pick) solution.
+ * This approach is often referred to as "Divide and Conquer" in the maximum
+ * subarray literature, although strictly speaking it is a linear recursion
+ * that for each element decides whether to pick it or not.
  * Complexity: O(n^2) in case if no memoization applied
  *
  * @param {Number[]} inputArray
- * @return {Number[]}
+ * @return {Number} - maximum subarray sum
  */
 export default function dcMaximumSubarraySum(inputArray) {
   /**

--- a/src/algorithms/sets/permutations/README.md
+++ b/src/algorithms/sets/permutations/README.md
@@ -18,7 +18,7 @@ Below are the permutations of string `ABC`.
 
 Or for example the first three people in a running race: you can't be first and second.
 
-**Number of combinations**
+**Number of permutations**
 
 ```
 n * (n-1) * (n -2) * ... * 1 = n!
@@ -31,7 +31,7 @@ For example, the lock below could be `333`.
 
 ![Permutation Lock](https://www.mathsisfun.com/combinatorics/images/permutation-lock.jpg)
 
-**Number of combinations**
+**Number of permutations**
 
 ```
 n * n * n ... (r times) = n^r

--- a/src/algorithms/sets/permutations/__test__/permutateWithRepetitions.test.js
+++ b/src/algorithms/sets/permutations/__test__/permutateWithRepetitions.test.js
@@ -1,6 +1,12 @@
 import permutateWithRepetitions from '../permutateWithRepetitions';
 
 describe('permutateWithRepetitions', () => {
+  it('should permutate empty set', () => {
+    // The only permutation of an empty set is the empty permutation.
+    expect(permutateWithRepetitions([])).toEqual([[]]);
+    expect(permutateWithRepetitions(['A', 'B'], 0)).toEqual([[]]);
+  });
+
   it('should permutate string with repetition', () => {
     const permutations1 = permutateWithRepetitions(['A']);
     expect(permutations1).toEqual([

--- a/src/algorithms/sets/permutations/__test__/permutateWithoutRepetitions.test.js
+++ b/src/algorithms/sets/permutations/__test__/permutateWithoutRepetitions.test.js
@@ -2,6 +2,13 @@ import permutateWithoutRepetitions from '../permutateWithoutRepetitions';
 import factorial from '../../../math/factorial/factorial';
 
 describe('permutateWithoutRepetitions', () => {
+  it('should permutate empty set', () => {
+    // The only permutation of an empty set is the empty permutation.
+    const permutations = permutateWithoutRepetitions([]);
+    expect(permutations.length).toBe(factorial(0));
+    expect(permutations).toEqual([[]]);
+  });
+
   it('should permutate string', () => {
     const permutations1 = permutateWithoutRepetitions(['A']);
     expect(permutations1).toEqual([

--- a/src/algorithms/sets/permutations/permutateWithRepetitions.js
+++ b/src/algorithms/sets/permutations/permutateWithRepetitions.js
@@ -7,6 +7,11 @@ export default function permutateWithRepetitions(
   permutationOptions,
   permutationLength = permutationOptions.length,
 ) {
+  // There is exactly one permutation of the zero length — the empty permutation.
+  if (permutationLength === 0) {
+    return [[]];
+  }
+
   if (permutationLength === 1) {
     return permutationOptions.map((permutationOption) => [permutationOption]);
   }

--- a/src/algorithms/sets/permutations/permutateWithoutRepetitions.js
+++ b/src/algorithms/sets/permutations/permutateWithoutRepetitions.js
@@ -3,6 +3,11 @@
  * @return {*[]}
  */
 export default function permutateWithoutRepetitions(permutationOptions) {
+  // There is exactly one way to permutate an empty set — the empty permutation.
+  if (permutationOptions.length === 0) {
+    return [[]];
+  }
+
   if (permutationOptions.length === 1) {
     return [permutationOptions];
   }

--- a/src/algorithms/sets/power-set/README.md
+++ b/src/algorithms/sets/power-set/README.md
@@ -96,7 +96,7 @@ Adding the 2nd element to all existing sets:
 [[], [1]] ← 2 = [[], [1], [2], [1, 2]]
 ```
 
-Adding the 3nd element to all existing sets:
+Adding the 3rd element to all existing sets:
 
 ```
 [[], [1], [2], [1, 2]] ← 3 = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]

--- a/src/algorithms/sets/power-set/caPowerSet.js
+++ b/src/algorithms/sets/power-set/caPowerSet.js
@@ -18,7 +18,7 @@ export default function caPowerSet(originalSet) {
     Adding the 2nd element to all existing sets:
     [[], [1]] ← 2 = [[], [1], [2], [1, 2]]
 
-    Adding the 3nd element to all existing sets:
+    Adding the 3rd element to all existing sets:
     [[], [1], [2], [1, 2]] ← 3 = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]
 
     And so on for the rest of the elements from originalSet.

--- a/src/algorithms/sorting/bucket-sort/BucketSort.js
+++ b/src/algorithms/sorting/bucket-sort/BucketSort.js
@@ -1,4 +1,4 @@
-import RadixSort from '../radix-sort/RadixSort';
+import QuickSort from '../quick-sort/QuickSort';
 
 /**
  * Bucket Sort
@@ -30,10 +30,10 @@ export default function BucketSort(arr, bucketsNum = 1) {
 
   // Sort individual buckets.
   for (let i = 0; i < buckets.length; i += 1) {
-    // Let's use the Radix Sorter here. This may give us
-    // the average O(n + k) time complexity to sort one bucket
-    // (where k is a number of digits in the longest number).
-    buckets[i] = new RadixSort().sort(buckets[i]);
+    // Let's use a comparison-based sorter here since bucket elements
+    // may be arbitrary numbers (i.e. negative ones or floats), which
+    // a digit-based sorter (like radix sort) cannot handle.
+    buckets[i] = new QuickSort().sort(buckets[i]);
   }
 
   // Merge sorted buckets into final output.

--- a/src/algorithms/sorting/bucket-sort/__test__/BucketSort.test.js
+++ b/src/algorithms/sorting/bucket-sort/__test__/BucketSort.test.js
@@ -30,4 +30,16 @@ describe('BucketSort', () => {
     expect(BucketSort(reverseArr)).toEqual(sortedArr);
     expect(BucketSort(sortedArr)).toEqual(sortedArr);
   });
+
+  it('should sort the array of floats', () => {
+    expect(BucketSort([0.42, 0.31], 1)).toEqual([0.31, 0.42]);
+    expect(BucketSort([0.9, 0.2, 0.5, 0.1], 2)).toEqual([0.1, 0.2, 0.5, 0.9]);
+  });
+
+  it('should sort the array with negative numbers', () => {
+    expect(BucketSort([3, -2, 5, -8, 0], 1)).toEqual([-8, -2, 0, 3, 5]);
+    expect(BucketSort([3, -2, 5, -8, 0], 3)).toEqual([-8, -2, 0, 3, 5]);
+    expect(BucketSort([-5, -10], 1)).toEqual([-10, -5]);
+    expect(BucketSort([-5, -10], 2)).toEqual([-10, -5]);
+  });
 });

--- a/src/algorithms/sorting/heap-sort/README.md
+++ b/src/algorithms/sorting/heap-sort/README.md
@@ -20,7 +20,7 @@ rather than a linear-time search to find the maximum.
 
 | Name                  | Best            | Average             | Worst               | Memory    | Stable    | Comments  |
 | --------------------- | :-------------: | :-----------------: | :-----------------: | :-------: | :-------: | :-------- |
-| **Heap sort**         | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | 1         | No        |           |
+| **Heap sort**         | n&nbsp;log(n)   | n&nbsp;log(n)       | n&nbsp;log(n)       | 1         | No        | Classic heapsort is in-place; this repo's implementation copies the items into a heap and thus uses O(n) memory |
 
 ## References
 

--- a/src/algorithms/sorting/radix-sort/RadixSort.js
+++ b/src/algorithms/sorting/radix-sort/RadixSort.js
@@ -1,6 +1,9 @@
 import Sort from '../Sort';
 
-// Using charCode (a = 97, b = 98, etc), we can map characters to buckets from 0 - 25
+// Using charCode (a = 97, b = 98, etc), we can map characters to buckets from 1 - 26.
+// Bucket 0 is reserved for the "no character at this position" case so that
+// shorter strings are sorted before longer strings with the same prefix
+// (e.g. 'b' goes before 'ba').
 const BASE_CHAR_CODE = 97;
 const NUMBER_OF_POSSIBLE_DIGITS = 10;
 const ENGLISH_ALPHABET_LENGTH = 26;
@@ -13,6 +16,27 @@ export default class RadixSort extends Sort {
   sort(originalArray) {
     // Assumes all elements of array are of the same type
     const isArrayOfNumbers = this.isArrayOfNumbers(originalArray);
+
+    if (isArrayOfNumbers) {
+      // Number buckets are formed of digits and thus can only handle
+      // non-negative integers. To sort negative numbers we sort their
+      // absolute values instead and then reverse and negate the result
+      // back, prepending it to the sorted non-negative numbers:
+      // [2, -1, -3] → negatives [1, 3] → sorted [1, 3]
+      // → reversed and negated [-3, -1] → result [-3, -1, 2]
+      const negativeNumbers = originalArray
+        .filter((number) => number < 0)
+        .map((number) => -number);
+
+      if (negativeNumbers.length) {
+        const nonNegativeNumbers = originalArray.filter((number) => number >= 0);
+
+        return [
+          ...this.sort(negativeNumbers).reverse().map((number) => -number),
+          ...this.sort(nonNegativeNumbers),
+        ];
+      }
+    }
 
     let sortedArray = [...originalArray];
     const numPasses = this.determineNumPasses(sortedArray);
@@ -67,7 +91,9 @@ export default class RadixSort extends Sort {
    * @return {*[]}
    */
   placeElementsInCharacterBuckets(array, index, numPasses) {
-    const buckets = this.createBuckets(ENGLISH_ALPHABET_LENGTH);
+    // One extra bucket (the very first one) is being used for the elements
+    // that have no character at the currently inspected position.
+    const buckets = this.createBuckets(ENGLISH_ALPHABET_LENGTH + 1);
 
     array.forEach((element) => {
       this.callbacks.visitingCallback(element);
@@ -79,24 +105,28 @@ export default class RadixSort extends Sort {
   }
 
   /**
+   * Get the bucket number for the character of the element that is being
+   * inspected during the current pass. Passes go through character positions
+   * from right to left (this is the least-significant-digit radix sort), so
+   * the pass number 0 inspects the very last possible character position.
+   *
    * @param {string} element
    * @param {number} index
    * @param {number} numPasses
    * @return {number}
    */
   getCharCodeOfElementAtIndex(element, index, numPasses) {
-    // Place element in last bucket if not ready to organize
-    if ((numPasses - index) > element.length) {
-      return ENGLISH_ALPHABET_LENGTH - 1;
+    const charPos = numPasses - index - 1;
+
+    // If the string is too short to have a character at this position then
+    // place it into the very first bucket, since the "absent character"
+    // must be sorted before 'a' ('b' goes before 'ba').
+    if (charPos > element.length - 1) {
+      return 0;
     }
 
-    /**
-     * If each character has been organized, use first character to determine bucket,
-     * otherwise iterate backwards through element
-     */
-    const charPos = index > element.length - 1 ? 0 : element.length - index - 1;
-
-    return element.toLowerCase().charCodeAt(charPos) - BASE_CHAR_CODE;
+    // Characters a-z occupy buckets 1-26 (bucket 0 is reserved above).
+    return element.toLowerCase().charCodeAt(charPos) - BASE_CHAR_CODE + 1;
   }
 
   /**

--- a/src/algorithms/sorting/radix-sort/__test__/RadixSort.test.js
+++ b/src/algorithms/sorting/radix-sort/__test__/RadixSort.test.js
@@ -9,6 +9,24 @@ describe('RadixSort', () => {
     SortTester.testSort(RadixSort);
   });
 
+  it('should sort negative numbers', () => {
+    SortTester.testNegativeNumbersSort(RadixSort);
+
+    const sorter = new RadixSort();
+    expect(sorter.sort([2, -1, -3])).toEqual([-3, -1, 2]);
+    expect(sorter.sort([-5, -10])).toEqual([-10, -5]);
+  });
+
+  it('should sort strings of different lengths lexicographically', () => {
+    const sorter = new RadixSort();
+
+    // Shorter strings must go before longer strings with the same prefix.
+    expect(sorter.sort(['b', 'ba'])).toEqual(['b', 'ba']);
+    expect(sorter.sort(['zzz', 'bb', 'a', 'rr', 'rrb', 'rrba'])).toEqual(
+      ['a', 'bb', 'rr', 'rrb', 'rrba', 'zzz'],
+    );
+  });
+
   it('should visit array of strings n (number of strings) x m (length of longest element) times', () => {
     SortTester.testAlgorithmTimeComplexity(
       RadixSort,

--- a/src/algorithms/sorting/selection-sort/README.md
+++ b/src/algorithms/sorting/selection-sort/README.md
@@ -4,7 +4,7 @@ _Read this in other languages:_
 [_Português_](README.pt-BR.md).
 
 Selection sort is a sorting algorithm, specifically an 
-in-place comparison sort. It has O(n2) time complexity, 
+in-place comparison sort. It has O(n<sup>2</sup>) time complexity, 
 making it inefficient on large lists, and generally 
 performs worse than the similar insertion sort. 
 Selection sort is noted for its simplicity, and it has 

--- a/src/algorithms/stack/valid-parentheses/README.md
+++ b/src/algorithms/stack/valid-parentheses/README.md
@@ -33,10 +33,10 @@ This is actually a very common interview question and a very good example of how
 The problem can be solved in two ways
 
 ### Bruteforce Approach
-We can iterate through the string and then for each character in the string, we check for it's last closing character in the the string. Once we find the last closing character in the string, we remove both characters and then repeat the iteration, if we don't find a closing character for an opening character, then the string is invalid. The time complexity of this would be O(n^2) which is not so efficient.
+We can iterate through the string and then, for each opening character in the string, search for its matching closing character. Once we find the matching closing character, we remove both characters and then repeat the iteration. If we don't find a closing character for an opening character, then the string is invalid. The time complexity of this would be O(n^2), which is not so efficient.
 
 ### Using a Stack
-We can use a hashtable to store all opening characters and the value would be the respective closing character. We can then iterate through the string and if we encounter an opening parantheses, we push it's closing character to the stack. If we ecounter a closing paraentheses, then we pop the stack and confirm that the popped element is equal to the current closing parentheses character. If it is not then the string is invalid. At the end of the iteration, we also need to check that the stack is empty. If it is not then the string is invalid. If it is, then the string is valid. This is a more efficient approach with a Time complexity and Space complexity of O(n).
+We can use a hashtable to store all opening characters as keys, with the respective closing character as the value. We can then iterate through the string, and if we encounter an opening parenthesis, we push its closing character to the stack. If we encounter a closing parenthesis, then we pop the stack and confirm that the popped element is equal to the current closing parenthesis character. If it is not, then the string is invalid. At the end of the iteration, we also need to check that the stack is empty. If it is not, then the string is invalid. If it is, then the string is valid (note that this makes an empty string valid — there are no brackets to mismatch). This is a more efficient approach with a time complexity and space complexity of O(n).
 
 
 ## References

--- a/src/algorithms/stack/valid-parentheses/__test__/validParentheses.test.js
+++ b/src/algorithms/stack/valid-parentheses/__test__/validParentheses.test.js
@@ -1,8 +1,9 @@
 import isValid from '../validParentheses';
 
 describe('validParentheses', () => {
-  it('should return false when string is empty', () => {
-    expect(isValid('')).toBe(false);
+  it('should return true when string is empty', () => {
+    // An empty string is vacuously valid — there are no brackets to mismatch.
+    expect(isValid('')).toBe(true);
   });
 
   it('should return true when string contains valid parentheses in correct order', () => {

--- a/src/algorithms/stack/valid-parentheses/validParentheses.js
+++ b/src/algorithms/stack/valid-parentheses/validParentheses.js
@@ -14,10 +14,6 @@ hashTable.set('[', ']');
  * @return {boolean}
  */
 export default function isValid(parenthesesString) {
-  // If string is empty return false
-  if (parenthesesString.length === 0) {
-    return false;
-  }
   // Create stack
   const stack = new Stack();
 

--- a/src/algorithms/statistics/weighted-random/__test__/weightedRandom.test.js
+++ b/src/algorithms/statistics/weighted-random/__test__/weightedRandom.test.js
@@ -24,6 +24,16 @@ describe('weightedRandom', () => {
     expect(weightedRandom(['a', 'b', 'c'], [1, 1, 0])).not.toEqual({ index: 2, item: 'c' });
   });
 
+  it('should not pick zero-weight items even when the random number is zero', () => {
+    const mathRandomSpy = jest.spyOn(Math, 'random').mockImplementation(() => 0);
+
+    // Without the strict comparison the leading zero-weight item 'a' would be
+    // picked here since its cumulative weight (0) equals the random number (0).
+    expect(weightedRandom(['a', 'b', 'c'], [0, 0.2, 0.8])).toEqual({ index: 1, item: 'b' });
+
+    mathRandomSpy.mockRestore();
+  });
+
   it('should correctly do random selection based on wights', () => {
     // Number of times we're going to select the random items based on their weights.
     const ATTEMPTS_NUM = 1000;

--- a/src/algorithms/statistics/weighted-random/weightedRandom.js
+++ b/src/algorithms/statistics/weighted-random/weightedRandom.js
@@ -41,8 +41,12 @@ export default function weightedRandom(items, weights) {
 
   // Picking the random item based on its weight.
   // The items with higher weight will be picked more often.
+  // The item with the index i "owns" the [cumulativeWeights[i - 1], cumulativeWeights[i])
+  // interval of the random numbers. The strict ">" comparison makes the interval of
+  // a zero-weight item empty, so such an item can never be picked (even when the
+  // random number is exactly 0).
   for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
-    if (cumulativeWeights[itemIndex] >= randomNumber) {
+    if (cumulativeWeights[itemIndex] > randomNumber) {
       return {
         item: items[itemIndex],
         index: itemIndex,

--- a/src/algorithms/string/hamming-distance/README.md
+++ b/src/algorithms/string/hamming-distance/README.md
@@ -1,6 +1,6 @@
 # Hamming Distance
 
-the Hamming distance between two strings of equal length is the 
+The Hamming distance between two strings of equal length is the 
 number of positions at which the corresponding symbols are 
 different. In other words, it measures the minimum number of
 substitutions required to change one string into the other, or 

--- a/src/algorithms/string/rabin-karp/__test__/rabinKarp.test.js
+++ b/src/algorithms/string/rabin-karp/__test__/rabinKarp.test.js
@@ -37,7 +37,9 @@ describe('rabinKarp', () => {
   it('should work with UTF symbols', () => {
     expect(rabinKarp('a\u{ffff}', '\u{ffff}')).toBe(1);
     expect(rabinKarp('\u0000耀\u0000', '耀\u0000')).toBe(1);
-    // @TODO: Provide Unicode support.
-    // expect(rabinKarp('a\u{20000}', '\u{20000}')).toBe(1);
+    expect(rabinKarp('a\u{20000}', '\u{20000}')).toBe(1);
+    // The astral symbol occupies two UTF-16 code units, thus the position is 2.
+    expect(rabinKarp('\u{20000}ba', 'ba')).toBe(2);
+    expect(rabinKarp('a\u{20000}baa', '\u{20000}b')).toBe(1);
   });
 });

--- a/src/algorithms/string/rabin-karp/rabinKarp.js
+++ b/src/algorithms/string/rabin-karp/rabinKarp.js
@@ -8,15 +8,25 @@ import PolynomialHash from '../../cryptography/polynomial-hash/PolynomialHash';
 export default function rabinKarp(text, word) {
   const hasher = new PolynomialHash();
 
+  // Work with code points (and not with UTF-16 code units) so that
+  // surrogate pairs (astral symbols) are hashed as single characters.
+  const textChars = Array.from(text);
+  const wordChars = Array.from(word);
+
   // Calculate word hash that we will use for comparison with other substring hashes.
   const wordHash = hasher.hash(word);
 
   let prevFrame = null;
   let currentFrameHash = null;
 
+  // The position of the current frame in terms of UTF-16 code units. It is being
+  // tracked separately because astral symbols occupy two code units at once and
+  // the returned position must stay compatible with String.prototype.indexOf().
+  let utf16Position = 0;
+
   // Go through all substring of the text that may match.
-  for (let charIndex = 0; charIndex <= (text.length - word.length); charIndex += 1) {
-    const currentFrame = text.substring(charIndex, charIndex + word.length);
+  for (let charIndex = 0; charIndex <= (textChars.length - wordChars.length); charIndex += 1) {
+    const currentFrame = textChars.slice(charIndex, charIndex + wordChars.length).join('');
 
     // Calculate the hash of current substring.
     if (currentFrameHash === null) {
@@ -30,12 +40,11 @@ export default function rabinKarp(text, word) {
     // Compare the hash of current substring and seeking string.
     // In case if hashes match let's make sure that substrings are equal.
     // In case of hash collision the strings may not be equal.
-    if (
-      wordHash === currentFrameHash
-      && text.substring(charIndex, charIndex + word.length) === word
-    ) {
-      return charIndex;
+    if (wordHash === currentFrameHash && currentFrame === word) {
+      return utf16Position;
     }
+
+    utf16Position += textChars[charIndex].length;
   }
 
   return -1;

--- a/src/algorithms/string/regular-expression-matching/regularExpressionMatching.js
+++ b/src/algorithms/string/regular-expression-matching/regularExpressionMatching.js
@@ -43,7 +43,9 @@ export default function regularExpressionMatching(string, pattern) {
   for (let columnIndex = 1; columnIndex <= pattern.length; columnIndex += 1) {
     const patternIndex = columnIndex - 1;
 
-    if (pattern[patternIndex] === ZERO_OR_MORE_CHARS) {
+    // The '*' char must have a preceding char to repeat (a pattern that
+    // starts with '*' is malformed and can't match anything).
+    if (pattern[patternIndex] === ZERO_OR_MORE_CHARS && patternIndex > 0) {
       matchMatrix[0][columnIndex] = matchMatrix[0][columnIndex - 2];
     } else {
       matchMatrix[0][columnIndex] = false;

--- a/src/algorithms/string/z-algorithm/README.md
+++ b/src/algorithms/string/z-algorithm/README.md
@@ -53,7 +53,7 @@ Z[] =  x 0 6 0 4 0 2 0
 ## Complexity
 
 - **Time:** `O(|W| + |T|)`
-- **Space:** `O(|W|)`
+- **Space:** `O(|W| + |T|)` (the Z-array is built over the concatenation of the word, the separator and the text)
 
 ## References
 

--- a/src/algorithms/string/z-algorithm/zAlgorithm.js
+++ b/src/algorithms/string/z-algorithm/zAlgorithm.js
@@ -115,11 +115,18 @@ export default function zAlgorithm(text, word) {
   const zArray = buildZArray(zString);
 
   // Based on Z-array properties each cell will tell us the length of the match between
-  // the string prefix and current sub-text. Thus we're may find all positions in zArray
-  // with the number that equals to the length of the word (zString prefix) and based on
-  // that positions we'll be able to calculate word positions in text.
-  for (let charIndex = 1; charIndex < zArray.length; charIndex += 1) {
-    if (zArray[charIndex] === word.length) {
+  // the string prefix and current sub-text. Thus we may find all positions in zArray
+  // with the number that is at least the length of the word (zString prefix) and based
+  // on that positions we'll be able to calculate word positions in text. We scan the
+  // text part of zString only and use ">=" comparison because in case the text itself
+  // contains the separator character the match may run over the separator and make the
+  // Z-value bigger than the word length.
+  for (
+    let charIndex = word.length + SEPARATOR.length;
+    charIndex < zArray.length;
+    charIndex += 1
+  ) {
+    if (zArray[charIndex] >= word.length) {
       // Since we did concatenation to form zString we need to subtract prefix
       // and separator lengths.
       const wordPosition = charIndex - word.length - SEPARATOR.length;

--- a/src/algorithms/tree/breadth-first-search/README.md
+++ b/src/algorithms/tree/breadth-first-search/README.md
@@ -15,12 +15,12 @@ BFS(root)
   Pre: root is the node of the BST
   Post: the nodes in the BST have been visited in breadth first order
   q ← queue
-  while root = ø
+  while root != ø
     yield root.value
-    if root.left = ø
+    if root.left != ø
       q.enqueue(root.left)
     end if
-    if root.right = ø
+    if root.right != ø
       q.enqueue(root.right)
     end if
     if !q.isEmpty()

--- a/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/README.md
+++ b/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/README.md
@@ -80,11 +80,11 @@ Since the algorithm requires only one pass through the prices array, the time co
 
 #### Additional Space Complexity
 
-Except of the prices array itself the algorithm consumes the constant amount of memory. Thus, additional space complexity is `O(1)`.
+Except for the prices array itself, the algorithm consumes a constant amount of memory. Thus, additional space complexity is `O(1)`.
 
 ## Accumulator Approach `O(n)`
 
-There is even simpler approach exists. Let's say we have the prices array which looks like this `[1, 7, 2, 3, 6, 7, 6, 7]`:
+There is an even simpler approach. Let's say we have the prices array which looks like this `[1, 7, 2, 3, 6, 7, 6, 7]`:
 
 ![Simple One Pass](https://leetcode.com/media/original_images/122_maxprofit_2.PNG)
 
@@ -100,7 +100,31 @@ Since the algorithm requires only one pass through the prices array, the time co
 
 #### Additional Space Complexity
 
-Except of the prices array itself the algorithm consumes the constant amount of memory. Thus, additional space complexity is `O(1)`.
+Except for the prices array itself, the algorithm consumes a constant amount of memory. Thus, additional space complexity is `O(1)`.
+
+## Dynamic Programming Approach `O(n)`
+
+We may also track two states for every day:
+
+- `lastBuy` — the maximum profit so far if we're currently _holding_ a stock (i.e. the last action was a "buy").
+- `lastSold` — the maximum profit so far if we're _not holding_ a stock (i.e. the last action was a "sell", or we haven't traded yet).
+
+On each day we may either keep the previous state or switch it:
+
+- `curBuy = Max(lastBuy, lastSold - price)` — keep holding, or buy at today's price.
+- `curSold = Max(lastSold, lastBuy + price)` — keep resting, or sell at today's price.
+
+After the last day the answer is `lastSold`, since the maximum profit always ends with a sale (still holding a stock at the end could only have decreased the profit).
+
+> See the full code example in [dpBestTimeToBuySellStocks.js](dpBestTimeToBuySellStocks.js)
+
+#### Time Complexity
+
+Since the algorithm requires only one pass through the prices array, the time complexity would equal `O(n)`.
+
+#### Additional Space Complexity
+
+Except for the prices array itself, the algorithm consumes a constant amount of memory. Thus, additional space complexity is `O(1)`.
 
 ## References
 

--- a/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/__tests__/peakvalleyBestTimeToBuySellStocks.test.js
+++ b/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/__tests__/peakvalleyBestTimeToBuySellStocks.test.js
@@ -4,6 +4,8 @@ describe('peakvalleyBestTimeToBuySellStocks', () => {
   it('should find the best time to buy and sell stocks', () => {
     let visit;
 
+    expect(peakvalleyBestTimeToBuySellStocks([])).toEqual(0);
+
     expect(peakvalleyBestTimeToBuySellStocks([1, 5])).toEqual(4);
 
     visit = jest.fn();

--- a/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/peakvalleyBestTimeToBuySellStocks.js
+++ b/src/algorithms/uncategorized/best-time-to-buy-sell-stocks/peakvalleyBestTimeToBuySellStocks.js
@@ -8,6 +8,12 @@
  */
 const peakvalleyBestTimeToBuySellStocks = (prices, visit = () => {}) => {
   visit();
+
+  // There is no way to make a profit out of an empty price list.
+  if (!prices.length) {
+    return 0;
+  }
+
   let profit = 0;
   let low = prices[0];
   let high = prices[0];

--- a/src/algorithms/uncategorized/hanoi-tower/__test__/hanoiTower.test.js
+++ b/src/algorithms/uncategorized/hanoi-tower/__test__/hanoiTower.test.js
@@ -59,4 +59,15 @@ describe('hanoiTower', () => {
 
     expect(moveCallback).toHaveBeenCalledTimes((2 ** numberOfDiscs) - 1);
   });
+
+  it('should not make any moves when there are no discs', () => {
+    const moveCallback = jest.fn();
+
+    hanoiTower({
+      numberOfDiscs: 0,
+      moveCallback,
+    });
+
+    expect(moveCallback).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/algorithms/uncategorized/hanoi-tower/hanoiTower.js
+++ b/src/algorithms/uncategorized/hanoi-tower/hanoiTower.js
@@ -14,6 +14,11 @@ function hanoiTowerRecursive({
   toPole,
   moveCallback,
 }) {
+  if (numberOfDiscs <= 0) {
+    // Base case with no discs — nothing to move.
+    return;
+  }
+
   if (numberOfDiscs === 1) {
     // Base case with just one disc.
     moveCallback(fromPole.peek(), fromPole.toArray(), toPole.toArray());

--- a/src/algorithms/uncategorized/jump-game/dpTopDownJumpGame.js
+++ b/src/algorithms/uncategorized/jump-game/dpTopDownJumpGame.js
@@ -28,13 +28,14 @@ export default function dpTopDownJumpGame(
     return true;
   }
 
-  // Init cell goodness table if it is empty.
-  // This is DYNAMIC PROGRAMMING feature.
-  const currentCellsGoodness = [...cellsGoodness];
+  // Init cell goodness table if it is empty. The table must be shared (and not
+  // copied) across the whole recursion tree so that every "bad" cell gets deeply
+  // visited only once. This is DYNAMIC PROGRAMMING feature.
+  const currentCellsGoodness = cellsGoodness;
   if (!currentCellsGoodness.length) {
     numbers.forEach(() => currentCellsGoodness.push(undefined));
     // Mark the last cell as "good" one since it is where we ultimately want to get.
-    currentCellsGoodness[cellsGoodness.length - 1] = true;
+    currentCellsGoodness[currentCellsGoodness.length - 1] = true;
   }
 
   // Check what the longest jump we could make from current position.

--- a/src/algorithms/uncategorized/rain-terraces/README.md
+++ b/src/algorithms/uncategorized/rain-terraces/README.md
@@ -33,7 +33,7 @@ Structure is like below:
 |  | |
 |__|_| 
 
-We can trap "3*2 units" of water between 3 an 2,
+We can trap "3*2 units" of water between 3 and 2,
 "1 unit" on top of bar 2 and "3 units" between 2 
 and 4. See below diagram also.
 ```
@@ -59,7 +59,7 @@ An element of array can store water if there are higher bars on left and right.
 We can find amount of water to be stored in every element by finding the heights 
 of bars on left and right sides. The idea is to compute amount of water that can
 be stored in every element of array. For example, consider the array
-`[3, 0, 0, 2, 0, 4]`, We can trap "3*2 units" of water between 3 an 2, "1 unit" 
+`[3, 0, 0, 2, 0, 4]`, We can trap "3*2 units" of water between 3 and 2, "1 unit" 
 on top of bar 2 and "3 units" between 2 and 4. See below diagram also.
 
 ### Approach 1: Brute force

--- a/src/algorithms/uncategorized/recursive-staircase/README.md
+++ b/src/algorithms/uncategorized/recursive-staircase/README.md
@@ -10,7 +10,7 @@ There are `n` stairs, a person standing at the bottom wants to reach the top. Th
 
 This is an interesting problem because there are several ways of how it may be solved that illustrate different programming paradigms.
 
-- [Brute Force Recursive Solution](./recursiveStaircaseBF.js) - Time: `O(2^n)`; Space: `O(1)`
+- [Brute Force Recursive Solution](./recursiveStaircaseBF.js) - Time: `O(2^n)`; Space: `O(n)` (recursion stack depth)
 - [Recursive Solution With Memoization](./recursiveStaircaseMEM.js) - Time: `O(n)`; Space: `O(n)`
 - [Dynamic Programming Solution](./recursiveStaircaseDP.js) - Time: `O(n)`; Space: `O(n)`
 - [Iterative Solution](./recursiveStaircaseIT.js) - Time: `O(n)`; Space: `O(1)` 

--- a/src/algorithms/uncategorized/square-matrix-rotation/README.md
+++ b/src/algorithms/uncategorized/square-matrix-rotation/README.md
@@ -63,11 +63,13 @@ Rotate the input matrix in-place such that it becomes:
 
 We would need to do two reflections of the matrix: 
 
-- reflect vertically
 - reflect diagonally from bottom-left to top-right
+- then reflect vertically (upside-down)
 
-Or we also could Furthermore, you can reflect diagonally 
-top-left/bottom-right and reflect horizontally.
+Or, alternatively, we could reflect diagonally along the
+top-left/bottom-right (main) diagonal first (i.e. transpose
+the matrix), and then reflect horizontally. This is the
+order that is illustrated below and used in the code.
 
 A common question is how do you even figure out what kind 
 of reflections to do? Simply rip a square piece of paper,
@@ -75,9 +77,9 @@ write a random word on it so you know its rotation. Then,
 flip the square piece of paper around until you figure out
 how to come to the solution.
  
-Here is an example of how first line may be rotated using
-diagonal top-right/bottom-left rotation along with horizontal
-rotation.
+Here is an example of how the first line may be rotated using
+the top-left/bottom-right diagonal reflection along with the
+horizontal reflection.
 
 ```
 Let's say we have a string at the top of the matrix:
@@ -86,7 +88,7 @@ A B C
 • • •
 • • •
 
-Let's do top-right/bottom-left diagonal reflection:
+Let's do the top-left/bottom-right diagonal reflection:
 
 A B C
 / / •
@@ -98,7 +100,7 @@ A → →
 B → →
 C → →
 
-The string has been rotated to 90 degree:
+The string has been rotated by 90 degrees:
 
 • • A
 • • B

--- a/src/algorithms/uncategorized/square-matrix-rotation/squareMatrixRotation.js
+++ b/src/algorithms/uncategorized/square-matrix-rotation/squareMatrixRotation.js
@@ -5,7 +5,7 @@
 export default function squareMatrixRotation(originalMatrix) {
   const matrix = originalMatrix.slice();
 
-  // Do top-right/bottom-left diagonal reflection of the matrix.
+  // Do top-left/bottom-right diagonal reflection of the matrix (transpose it).
   for (let rowIndex = 0; rowIndex < matrix.length; rowIndex += 1) {
     for (let columnIndex = rowIndex + 1; columnIndex < matrix.length; columnIndex += 1) {
       // Swap elements.

--- a/src/algorithms/uncategorized/unique-paths/README.md
+++ b/src/algorithms/uncategorized/unique-paths/README.md
@@ -36,9 +36,9 @@ Output: 28
 
 ### Backtracking
 
-First thought that might came to mind is that we need to build a decision tree 
+The first thought that might come to mind is that we need to build a decision tree 
 where `D` means moving down and `R` means moving right. For example in case
-of boars `width = 3` and `height = 2` we will have the following decision tree:
+of a board with `width = 3` and `height = 2` we will have the following decision tree:
 
 ```
                 START

--- a/src/data-structures/deque/README.md
+++ b/src/data-structures/deque/README.md
@@ -46,10 +46,11 @@ A deque is the right tool when you need **O(1) access at both ends**:
 
 - **Sliding window maximum/minimum** — maintain candidates in a monotonic deque
   so each element is pushed and popped at most once (overall O(n)).
-- **Browser history** — navigate backward (`removeFront`) and forward
-  (`removeBack`) through pages.
-- **Undo / redo stacks** — push actions to the back, undo from the back,
-  redo from the front.
+- **Browser history** — append freshly visited pages to the back and, once
+  the history size limit is reached, drop the oldest entries from the front.
+- **Bounded undo history** — push actions to the back and undo from the back
+  (like a stack), while old actions beyond the undo limit are evicted from
+  the front.
 - **Palindrome checking** — compare characters from both ends simultaneously.
 - **Work-stealing schedulers** (e.g. Java's `ForkJoinPool`) — threads push/pop
   from their own back, while idle threads steal from another thread's front.

--- a/src/data-structures/disjoint-set/DisjointSetItem.js
+++ b/src/data-structures/disjoint-set/DisjointSetItem.js
@@ -39,7 +39,7 @@ export default class DisjointSetItem {
   }
 
   /**
-   * Rank basically means the number of all ancestors.
+   * Rank basically means the number of all descendants.
    *
    * @return {number}
    */

--- a/src/data-structures/disjoint-set/README.md
+++ b/src/data-structures/disjoint-set/README.md
@@ -9,6 +9,12 @@ _Read this in other languages:_
 structure that tracks a set of elements partitioned into a number of disjoint (non-overlapping) subsets.
 It provides near-constant-time operations (bounded by the inverse Ackermann function) to _add new sets_,
 to _merge existing sets_, and to _determine whether elements are in the same set_.
+
+> Note: the near-constant-time bound requires both _union by rank/size_ and
+> _path compression_ optimizations. Of the two implementations in this folder,
+> [`DisjointSetAdhoc.js`](./DisjointSetAdhoc.js) applies both of them, while the educational
+> [`DisjointSet.js`](./DisjointSet.js) recomputes ranks on every union and doesn't compress
+> paths, so its union operation takes linear (rather than near-constant) time.
 In addition to many other uses (see the Applications section), disjoint-sets play a key role in Kruskal's algorithm for finding the minimum spanning tree of a graph.
 
 ![disjoint set](https://upload.wikimedia.org/wikipedia/commons/6/67/Dsu_disjoint_sets_init.svg)

--- a/src/data-structures/graph/Graph.js
+++ b/src/data-structures/graph/Graph.js
@@ -82,14 +82,22 @@ export default class Graph {
       this.edges[edge.getKey()] = edge;
     }
 
-    // Add edge to the vertices.
+    // Add edge to the vertices. Skip the vertices that already have this edge
+    // attached (it happens when the same edge instance is being added to
+    // several graphs, i.e. while building a minimum spanning tree).
     if (this.isDirected) {
       // If graph IS directed then add the edge only to start vertex.
-      startVertex.addEdge(edge);
+      if (!startVertex.hasEdge(edge)) {
+        startVertex.addEdge(edge);
+      }
     } else {
       // If graph ISN'T directed then add the edge to both vertices.
-      startVertex.addEdge(edge);
-      endVertex.addEdge(edge);
+      if (!startVertex.hasEdge(edge)) {
+        startVertex.addEdge(edge);
+      }
+      if (!endVertex.hasEdge(edge)) {
+        endVertex.addEdge(edge);
+      }
     }
 
     return this;

--- a/src/data-structures/hash-table/HashTable.js
+++ b/src/data-structures/hash-table/HashTable.js
@@ -14,8 +14,10 @@ export default class HashTable {
     // Create hash table of certain size and fill each bucket with empty linked list.
     this.buckets = Array(hashTableSize).fill(null).map(() => new LinkedList());
 
-    // Just to keep track of all actual keys in a fast way.
-    this.keys = {};
+    // Just to keep track of all actual keys in a fast way. The prototype-less
+    // object is used so that special keys (i.e. '__proto__') are stored
+    // reliably as plain own properties.
+    this.keys = Object.create(null);
   }
 
   /**

--- a/src/data-structures/hash-table/__test__/HashTable.test.js
+++ b/src/data-structures/hash-table/__test__/HashTable.test.js
@@ -114,4 +114,14 @@ describe('HashTable', () => {
 
     expect(hashTable.getValues()).toEqual(['one', 'two', 'three']);
   });
+
+  it('should track special object keys in the keys registry', () => {
+    const hashTable = new HashTable();
+
+    hashTable.set('__proto__', 'x');
+
+    expect(hashTable.get('__proto__')).toBe('x');
+    expect(hashTable.has('__proto__')).toBe(true);
+    expect(hashTable.getKeys()).toEqual(['__proto__']);
+  });
 });

--- a/src/data-structures/heap/Heap.js
+++ b/src/data-structures/heap/Heap.js
@@ -169,10 +169,12 @@ export default class Heap {
 
         // If there is no parent or parent is in correct order with the node
         // we're going to delete then heapify down. Otherwise heapify up.
+        // Check the parent existence by index (and not by the item truthiness)
+        // since the parent item value may be falsy (i.e. 0 or an empty string).
         if (
           this.hasLeftChild(indexToRemove)
           && (
-            !parentItem
+            !this.hasParent(indexToRemove)
             || this.pairIsInCorrectOrder(parentItem, this.heapContainer[indexToRemove])
           )
         ) {

--- a/src/data-structures/heap/MaxHeapAdhoc.js
+++ b/src/data-structures/heap/MaxHeapAdhoc.js
@@ -7,7 +7,8 @@
 class MaxHeapAdhoc {
   constructor(heap = []) {
     this.heap = [];
-    heap.forEach(this.add);
+    // Use an arrow function so that `this` inside add() refers to the heap.
+    heap.forEach((num) => this.add(num));
   }
 
   add(num) {

--- a/src/data-structures/heap/MinHeapAdhoc.js
+++ b/src/data-structures/heap/MinHeapAdhoc.js
@@ -7,7 +7,8 @@
 class MinHeapAdhoc {
   constructor(heap = []) {
     this.heap = [];
-    heap.forEach(this.add);
+    // Use an arrow function so that `this` inside add() refers to the heap.
+    heap.forEach((num) => this.add(num));
   }
 
   add(num) {

--- a/src/data-structures/heap/__test__/MaxHeapAdhoc.test.js
+++ b/src/data-structures/heap/__test__/MaxHeapAdhoc.test.js
@@ -9,6 +9,13 @@ describe('MaxHeapAdhoc', () => {
     expect(maxHeap.isEmpty()).toBe(true);
   });
 
+  it('should create a max heap from the initial array', () => {
+    const maxHeap = new MaxHeap([1, 3, 2]);
+
+    expect(maxHeap.peek()).toBe(3);
+    expect(maxHeap.isEmpty()).toBe(false);
+  });
+
   it('should add items to the heap and heapify it up', () => {
     const maxHeap = new MaxHeap();
 

--- a/src/data-structures/heap/__test__/MinHeap.test.js
+++ b/src/data-structures/heap/__test__/MinHeap.test.js
@@ -191,4 +191,20 @@ describe('MinHeap', () => {
     minHeap.remove(4);
     expect(minHeap.toString()).toBe('1,5,3,8,9,6,7');
   });
+
+  it('should keep the heap invariant when removing items with falsy values around', () => {
+    // The parent of the moved item has value 0 here, so the parent check
+    // must be done by index (and not by the item truthiness).
+    const minHeap = new MinHeap();
+    [-10, 0, -9, 4, 5, -8, -7, 6, 7, 8, 9, -8].forEach((value) => minHeap.add(value));
+
+    minHeap.remove(4);
+
+    // Polling must return the items in the ascending order.
+    const polledValues = [];
+    while (!minHeap.isEmpty()) {
+      polledValues.push(minHeap.poll());
+    }
+    expect(polledValues).toEqual([...polledValues].sort((a, b) => a - b));
+  });
 });

--- a/src/data-structures/heap/__test__/MinHeapAdhoc.test.js
+++ b/src/data-structures/heap/__test__/MinHeapAdhoc.test.js
@@ -9,6 +9,13 @@ describe('MinHeapAdhoc', () => {
     expect(minHeap.isEmpty()).toBe(true);
   });
 
+  it('should create a min heap from the initial array', () => {
+    const minHeap = new MinHeapAdhoc([3, 1, 2]);
+
+    expect(minHeap.peek()).toBe(1);
+    expect(minHeap.isEmpty()).toBe(false);
+  });
+
   it('should add items to the heap and heapify it up', () => {
     const minHeap = new MinHeapAdhoc();
 

--- a/src/data-structures/linked-list/LinkedList.js
+++ b/src/data-structures/linked-list/LinkedList.js
@@ -75,6 +75,11 @@ export default class LinkedList {
       if (currentNode) {
         newNode.next = currentNode.next;
         currentNode.next = newNode;
+        // If the new node was attached after the tail node
+        // then the tail reference needs to be updated.
+        if (this.tail === currentNode) {
+          this.tail = newNode;
+        }
       } else {
         if (this.tail) {
           this.tail.next = newNode;

--- a/src/data-structures/linked-list/__test__/LinkedList.test.js
+++ b/src/data-structures/linked-list/__test__/LinkedList.test.js
@@ -279,4 +279,19 @@ describe('LinkedList', () => {
     expect(linkedList.head.value).toBe(1);
     expect(linkedList.tail.value).toBe(3);
   });
+
+  it('should update the tail when inserting at the end of the list', () => {
+    const linkedList = new LinkedList();
+    linkedList.fromArray(['a', 'b', 'c']);
+
+    linkedList.insert('v', 3);
+
+    expect(linkedList.toString()).toBe('a,b,c,v');
+    expect(linkedList.tail.value).toBe('v');
+
+    // The following append must not discard the inserted node.
+    linkedList.append('w');
+    expect(linkedList.toString()).toBe('a,b,c,v,w');
+    expect(linkedList.tail.value).toBe('w');
+  });
 });

--- a/src/data-structures/lru-cache/LRUCache.js
+++ b/src/data-structures/lru-cache/LRUCache.js
@@ -35,7 +35,10 @@ class LRUCache {
    */
   constructor(capacity) {
     this.capacity = capacity; // How many items to store in cache at max.
-    this.nodesMap = {}; // The quick links to each linked list node in cache.
+    // The quick links to each linked list node in cache. The prototype-less
+    // object is used so that inherited properties (i.e. 'constructor' or
+    // 'toString' keys) don't collide with the cached keys.
+    this.nodesMap = Object.create(null);
     this.size = 0; // The number of items that is currently stored in the cache.
     this.head = new LinkedListNode(); // The Head (first) linked list node.
     this.tail = new LinkedListNode(); // The Tail (last) linked list node.

--- a/src/data-structures/lru-cache/README.md
+++ b/src/data-structures/lru-cache/README.md
@@ -33,7 +33,7 @@ You may also find more test-case examples of how the LRU Cache works in [LRUCach
 
 The first implementation that uses doubly linked list is good for learning purposes and for better understanding of how the average `O(1)` time complexity is achievable while doing `set()` and `get()`.
 
-However, the simpler approach might be to use a JavaScript [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object. The `Map` object holds key-value pairs and **remembers the original insertion order** of the keys. We can use this fact in order to keep the recently-used items in the "end" of the map by removing and re-adding items. The item at the beginning of the `Map` is the first one to be evicted if cache capacity overflows. The order of the items may checked by using the `IterableIterator` like `map.keys()`.
+However, the simpler approach might be to use a JavaScript [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object. The `Map` object holds key-value pairs and **remembers the original insertion order** of the keys. We can use this fact in order to keep the recently-used items in the "end" of the map by removing and re-adding items. The item at the beginning of the `Map` is the first one to be evicted if cache capacity overflows. The order of the items may be checked by using the `IterableIterator` like `map.keys()`.
 
 See the `LRUCacheOnMap` implementation example in [LRUCacheOnMap.js](./LRUCacheOnMap.js).
 

--- a/src/data-structures/lru-cache/__test__/LRUCache.test.js
+++ b/src/data-structures/lru-cache/__test__/LRUCache.test.js
@@ -147,4 +147,18 @@ describe('LRUCache', () => {
     expect(cache.get('key-5')).toBe(5);
     expect(cache.get('key-6')).toBe(6);
   });
+
+  it('should work with keys that exist on Object prototype', () => {
+    const cache = new LRUCache(5);
+
+    cache.set('constructor', 1);
+    cache.set('toString', 2);
+    cache.set('hasOwnProperty', 3);
+    cache.set('__proto__', 4);
+
+    expect(cache.get('constructor')).toBe(1);
+    expect(cache.get('toString')).toBe(2);
+    expect(cache.get('hasOwnProperty')).toBe(3);
+    expect(cache.get('__proto__')).toBe(4);
+  });
 });

--- a/src/data-structures/priority-queue/PriorityQueue.js
+++ b/src/data-structures/priority-queue/PriorityQueue.js
@@ -18,6 +18,11 @@ export default class PriorityQueue extends MinHeap {
 
   /**
    * Add item to the priority queue.
+   *
+   * Note that the priorities are keyed by the item value, so all equal
+   * items share one priority: adding an already-queued value with a new
+   * priority re-prioritizes every queued instance of that value.
+   *
    * @param {*} item - item we're going to add to the queue.
    * @param {number} [priority] - items priority.
    * @return {PriorityQueue}

--- a/src/data-structures/tree/BinaryTreeNode.js
+++ b/src/data-structures/tree/BinaryTreeNode.js
@@ -166,12 +166,14 @@ export default class BinaryTreeNode {
     }
 
     if (this.left && this.nodeComparator.equal(this.left, nodeToReplace)) {
-      this.left = replacementNode;
+      // setLeft() keeps the parent references of both nodes consistent.
+      this.setLeft(replacementNode);
       return true;
     }
 
     if (this.right && this.nodeComparator.equal(this.right, nodeToReplace)) {
-      this.right = replacementNode;
+      // setRight() keeps the parent references of both nodes consistent.
+      this.setRight(replacementNode);
       return true;
     }
 

--- a/src/data-structures/tree/avl-tree/AvlTree.js
+++ b/src/data-structures/tree/avl-tree/AvlTree.js
@@ -21,11 +21,36 @@ export default class AvlTree extends BinarySearchTree {
    * @return {boolean}
    */
   remove(value) {
-    // Do standard BST removal.
-    super.remove(value);
+    // Find the node that is going to be removed and remember the deepest
+    // node from which the tree may become unbalanced — that is the parent
+    // of the node that will be physically detached from the tree.
+    const nodeToRemove = this.root.find(value);
 
-    // Balance the tree starting from the root node.
-    this.balance(this.root);
+    let retraceStartNode = null;
+    if (nodeToRemove) {
+      if (nodeToRemove.left && nodeToRemove.right) {
+        // The node's value will be replaced with the next bigger value and
+        // the next bigger node itself will be detached from its parent.
+        const nextBiggerNode = nodeToRemove.right.findMin();
+        retraceStartNode = nextBiggerNode !== nodeToRemove.right
+          ? nextBiggerNode.parent
+          : nodeToRemove;
+      } else {
+        retraceStartNode = nodeToRemove.parent;
+      }
+    }
+
+    // Do standard BST removal.
+    const result = super.remove(value);
+
+    // Let's move up to the root and restore the balance along the way.
+    let currentNode = retraceStartNode || this.root;
+    while (currentNode) {
+      this.balance(currentNode);
+      currentNode = currentNode.parent;
+    }
+
+    return result;
   }
 
   /**
@@ -33,21 +58,23 @@ export default class AvlTree extends BinarySearchTree {
    */
   balance(node) {
     // If balance factor is not OK then try to balance the node.
+    // The zero balance factor of a child (possible after removals)
+    // is handled with a single rotation.
     if (node.balanceFactor > 1) {
       // Left rotation.
-      if (node.left.balanceFactor > 0) {
+      if (node.left.balanceFactor >= 0) {
         // Left-Left rotation
         this.rotateLeftLeft(node);
-      } else if (node.left.balanceFactor < 0) {
+      } else {
         // Left-Right rotation.
         this.rotateLeftRight(node);
       }
     } else if (node.balanceFactor < -1) {
       // Right rotation.
-      if (node.right.balanceFactor < 0) {
+      if (node.right.balanceFactor <= 0) {
         // Right-Right rotation
         this.rotateRightRight(node);
-      } else if (node.right.balanceFactor > 0) {
+      } else {
         // Right-Left rotation.
         this.rotateRightLeft(node);
       }
@@ -62,18 +89,27 @@ export default class AvlTree extends BinarySearchTree {
     const leftNode = rootNode.left;
     rootNode.setLeft(null);
 
-    // Make left node to be a child of rootNode's parent.
+    // Make left node to be a child of rootNode's parent
+    // (on the same side where rootNode used to be).
     if (rootNode.parent) {
-      rootNode.parent.setLeft(leftNode);
+      if (rootNode.parent.left === rootNode) {
+        rootNode.parent.setLeft(leftNode);
+      } else {
+        rootNode.parent.setRight(leftNode);
+      }
     } else if (rootNode === this.root) {
       // If root node is root then make left node to be a new root.
       this.root = leftNode;
     }
 
-    // If left node has a right child then detach it and
-    // attach it as a left child for rootNode.
+    // If left node has a right child then detach it first and
+    // then attach it as a left child for rootNode. The detach must
+    // happen first, otherwise the child's fresh parent reference
+    // would be erased by the detachment.
     if (leftNode.right) {
-      rootNode.setLeft(leftNode.right);
+      const leftRightNode = leftNode.right;
+      leftNode.setRight(null);
+      rootNode.setLeft(leftRightNode);
     }
 
     // Attach rootNode to the right of leftNode.
@@ -92,10 +128,12 @@ export default class AvlTree extends BinarySearchTree {
     const leftRightNode = leftNode.right;
     leftNode.setRight(null);
 
-    // Preserve leftRightNode's left subtree.
+    // Preserve leftRightNode's left subtree. Detach it first so that
+    // its fresh parent reference isn't erased by the detachment.
     if (leftRightNode.left) {
-      leftNode.setRight(leftRightNode.left);
+      const leftRightLeftNode = leftRightNode.left;
       leftRightNode.setLeft(null);
+      leftNode.setRight(leftRightLeftNode);
     }
 
     // Attach leftRightNode to the rootNode.
@@ -120,9 +158,12 @@ export default class AvlTree extends BinarySearchTree {
     const rightLeftNode = rightNode.left;
     rightNode.setLeft(null);
 
+    // Preserve rightLeftNode's right subtree. Detach it first so that
+    // its fresh parent reference isn't erased by the detachment.
     if (rightLeftNode.right) {
-      rightNode.setLeft(rightLeftNode.right);
+      const rightLeftRightNode = rightLeftNode.right;
       rightLeftNode.setRight(null);
+      rightNode.setLeft(rightLeftRightNode);
     }
 
     // Attach rightLeftNode to the rootNode.
@@ -143,18 +184,27 @@ export default class AvlTree extends BinarySearchTree {
     const rightNode = rootNode.right;
     rootNode.setRight(null);
 
-    // Make right node to be a child of rootNode's parent.
+    // Make right node to be a child of rootNode's parent
+    // (on the same side where rootNode used to be).
     if (rootNode.parent) {
-      rootNode.parent.setRight(rightNode);
+      if (rootNode.parent.right === rootNode) {
+        rootNode.parent.setRight(rightNode);
+      } else {
+        rootNode.parent.setLeft(rightNode);
+      }
     } else if (rootNode === this.root) {
       // If root node is root then make right node to be a new root.
       this.root = rightNode;
     }
 
-    // If right node has a left child then detach it and
-    // attach it as a right child for rootNode.
+    // If right node has a left child then detach it first and
+    // then attach it as a right child for rootNode. The detach must
+    // happen first, otherwise the child's fresh parent reference
+    // would be erased by the detachment.
     if (rightNode.left) {
-      rootNode.setRight(rightNode.left);
+      const rightLeftNode = rightNode.left;
+      rightNode.setLeft(null);
+      rootNode.setRight(rightLeftNode);
     }
 
     // Attach rootNode to the left of rightNode.

--- a/src/data-structures/tree/avl-tree/README.md
+++ b/src/data-structures/tree/avl-tree/README.md
@@ -40,7 +40,7 @@ AVL tree with balance factors (green)
 
 **Right-Left Rotation**
 
-![Right-Right Rotation](http://btechsmartclass.com/data_structures/ds_images/RL%20Rotation.png)
+![Right-Left Rotation](http://btechsmartclass.com/data_structures/ds_images/RL%20Rotation.png)
 
 ## References
 

--- a/src/data-structures/tree/avl-tree/__test__/AvlTRee.test.js
+++ b/src/data-structures/tree/avl-tree/__test__/AvlTRee.test.js
@@ -300,4 +300,77 @@ describe('AvlTree', () => {
     expect(tree.root.height).toBe(2);
     expect(tree.root.balanceFactor).toBe(0);
   });
+
+  it('should not lose subtrees when rotating a node that is a right child', () => {
+    // A left-left rotation is needed at node 70, which is the RIGHT child
+    // of the root. The rotated-up node must be attached to the same side
+    // of the parent where the unbalanced node used to be.
+    const tree = new AvlTree();
+    [50, 30, 70, 65, 60].forEach((value) => tree.insert(value));
+
+    expect(tree.toString()).toBe('30,50,60,65,70');
+    expect(tree.contains(30)).toBe(true);
+  });
+
+  it('should rebalance interior nodes after removal', () => {
+    const tree = new AvlTree();
+    [30, 20, 40, 10, 25, 50, 5].forEach((value) => tree.insert(value));
+
+    tree.remove(25);
+
+    expect(tree.toString()).toBe('5,10,20,30,40,50');
+
+    // Every node must satisfy the AVL invariant.
+    const checkBalance = (node) => {
+      if (!node) {
+        return;
+      }
+      expect(Math.abs(node.balanceFactor)).toBeLessThanOrEqual(1);
+      checkBalance(node.left);
+      checkBalance(node.right);
+    };
+    checkBalance(tree.root);
+  });
+
+  it('should keep the AVL invariant under a mixed insert/remove workload', () => {
+    const tree = new AvlTree();
+    const values = [];
+
+    // Deterministic pseudo-random sequence (linear congruential generator).
+    let seed = 42;
+    const nextRandom = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed;
+    };
+
+    for (let i = 0; i < 200; i += 1) {
+      const value = nextRandom() % 1000;
+      if (!values.includes(value)) {
+        values.push(value);
+        tree.insert(value);
+      }
+    }
+
+    // Remove half of the values in pseudo-random order.
+    const removedCount = Math.floor(values.length / 2);
+    for (let i = 0; i < removedCount; i += 1) {
+      const removeIndex = nextRandom() % values.length;
+      const [value] = values.splice(removeIndex, 1);
+      tree.remove(value);
+    }
+
+    const expectedString = [...values].sort((a, b) => a - b).join(',');
+    expect(tree.toString()).toBe(expectedString);
+
+    // Every node must satisfy the AVL invariant.
+    const checkBalance = (node) => {
+      if (!node) {
+        return;
+      }
+      expect(Math.abs(node.balanceFactor)).toBeLessThanOrEqual(1);
+      checkBalance(node.left);
+      checkBalance(node.right);
+    };
+    checkBalance(tree.root);
+  });
 });

--- a/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
+++ b/src/data-structures/tree/binary-search-tree/BinarySearchTreeNode.js
@@ -101,9 +101,13 @@ export default class BinarySearchTreeNode extends BinaryTreeNode {
       if (parent) {
         // Node has a parent. Just remove the pointer to this node from the parent.
         parent.removeChild(nodeToRemove);
+        // Clear the parent reference of the detached node.
+        nodeToRemove.parent = null;
       } else {
-        // Node has no parent. Just erase current node value.
-        nodeToRemove.setValue(undefined);
+        // Node has no parent. Just erase current node value. The null value
+        // (and not undefined) is used here as an "empty node" marker since
+        // this is what the insert() method checks for.
+        nodeToRemove.setValue(null);
       }
     } else if (nodeToRemove.left && nodeToRemove.right) {
       // Node has two children.
@@ -127,13 +131,16 @@ export default class BinarySearchTreeNode extends BinaryTreeNode {
 
       if (parent) {
         parent.replaceChild(nodeToRemove, childNode);
+        // Clear the parent reference of the detached node.
+        nodeToRemove.parent = null;
       } else {
         BinaryTreeNode.copyNode(childNode, nodeToRemove);
       }
     }
 
-    // Clear the parent of removed node.
-    nodeToRemove.parent = null;
+    // Note that in the "two children" case (and in the parentless cases above)
+    // the node object itself stays in the tree (only its value is replaced),
+    // so its parent reference must be left intact.
 
     return true;
   }

--- a/src/data-structures/tree/binary-search-tree/README.md
+++ b/src/data-structures/tree/binary-search-tree/README.md
@@ -145,7 +145,7 @@ end remove
 findParent(value, root)
   Pre: value is the value of the node we want to find the parent of
        root is the root node of the BST and is != ø
-  Post: a reference to the prent node of value if found; otherwise ø
+  Post: a reference to the parent node of value if found; otherwise ø
   if value = root.value
     return ø
   end if
@@ -173,7 +173,7 @@ end findParent
 
 ```text
 findNode(root, value)
-  Pre: value is the value of the node we want to find the parent of
+  Pre: value is the value of the node we want to find
        root is the root node of the BST
   Post: a reference to the node of value if found; otherwise ø
   if root = ø
@@ -194,7 +194,7 @@ end findNode
 ```text
 findMin(root)
   Pre: root is the root node of the BST
-    root = ø
+    root != ø
   Post: the smallest value in the BST is located
   if root.left = ø
     return root.value
@@ -208,7 +208,7 @@ end findMin
 ```text
 findMax(root)
   Pre: root is the root node of the BST
-    root = ø
+    root != ø
   Post: the largest value in the BST is located
   if root.right = ø
     return root.value
@@ -268,6 +268,13 @@ end postorder
 | Access    | Search    | Insertion | Deletion  |
 | :-------: | :-------: | :-------: | :-------: |
 | O(log(n)) | O(log(n)) | O(log(n)) | O(log(n)) |
+
+> The `O(log(n))` complexities above are for the **average** case (a reasonably
+> balanced tree). This basic BST is not self-balancing, so in the worst case
+> (i.e. when the values are inserted in sorted order) the tree degenerates into
+> a linked list and all the operations take `O(n)` time. Self-balancing trees
+> (i.e. [AVL Tree](../avl-tree) or [Red-Black Tree](../red-black-tree))
+> guarantee `O(log(n))` in the worst case as well.
 
 ### Space Complexity
 

--- a/src/data-structures/tree/binary-search-tree/__test__/BinarySearchTree.test.js
+++ b/src/data-structures/tree/binary-search-tree/__test__/BinarySearchTree.test.js
@@ -95,4 +95,38 @@ describe('BinarySearchTree', () => {
     expect(bst.toString()).toBe('-20,-10,4,6,10,20,25');
     expect(bst.root.height).toBe(3);
   });
+
+  it('should keep parent references consistent when removing a node with two children', () => {
+    const bst = new BinarySearchTree();
+    bst.insert(10);
+    bst.insert(20);
+    bst.insert(15);
+    bst.insert(25);
+
+    // Node 20 has two children — its value gets replaced, so it must
+    // keep its parent reference.
+    bst.remove(20);
+
+    expect(bst.toString()).toBe('10,15,25');
+    expect(bst.root.right.parent).toBe(bst.root);
+
+    // Removing the rest must properly detach the nodes.
+    bst.remove(15);
+    bst.remove(25);
+
+    expect(bst.toString()).toBe('10');
+    expect(bst.root.left).toBeNull();
+    expect(bst.root.right).toBeNull();
+  });
+
+  it('should allow to insert into the tree again after all nodes were removed', () => {
+    const bst = new BinarySearchTree();
+    bst.insert(10);
+    bst.remove(10);
+
+    bst.insert(20);
+
+    expect(bst.toString()).toBe('20');
+    expect(bst.root.value).toBe(20);
+  });
 });

--- a/src/data-structures/tree/red-black-tree/RedBlackTree.js
+++ b/src/data-structures/tree/red-black-tree/RedBlackTree.js
@@ -17,6 +17,14 @@ export default class RedBlackTree extends BinarySearchTree {
   insert(value) {
     const insertedNode = super.insert(value);
 
+    // In case if the value already existed in the tree, the returned node
+    // is the existing (already colored) one. Its color must be left intact,
+    // otherwise re-inserting a black node's value would repaint it red and
+    // break the red-black invariants.
+    if (this.isNodeColored(insertedNode)) {
+      return insertedNode;
+    }
+
     // if (!this.root.left && !this.root.right) {
     if (this.nodeComparator.equal(insertedNode, this.root)) {
       // Make root to always be black.

--- a/src/data-structures/tree/red-black-tree/__test__/RedBlackTree.test.js
+++ b/src/data-structures/tree/red-black-tree/__test__/RedBlackTree.test.js
@@ -321,4 +321,21 @@ describe('RedBlackTree', () => {
 
     expect(removeNodeFromRedBlackTree).toThrow();
   });
+
+  it('should preserve the node color when inserting a duplicate value', () => {
+    const tree = new RedBlackTree();
+
+    tree.insert(10);
+    tree.insert(5);
+    tree.insert(20);
+    tree.insert(25);
+
+    const node20 = tree.root.find(20);
+    expect(tree.isNodeBlack(node20)).toBe(true);
+
+    // Re-inserting an existing value must not repaint the existing node.
+    tree.insert(20);
+
+    expect(tree.isNodeBlack(node20)).toBe(true);
+  });
 });

--- a/src/data-structures/tree/segment-tree/README.md
+++ b/src/data-structures/tree/segment-tree/README.md
@@ -17,10 +17,9 @@ children of each node corresponds to the two halves of
 the array corresponding to the node.
 
 We build the tree bottom up, with the value of each node 
-being the "minimum" (or any other function) of its children's values. This will 
-take `O(n log n)` time. The number 
-of operations done is the height of the tree, which 
-is `O(log n)`. To do range queries, each node splits the 
+being the "minimum" (or any other function) of its children's values. Since 
+every one of the (roughly `2n`) tree nodes is visited once, building the tree
+takes `O(n)` time. To do range queries, each node splits the 
 query into two parts, one sub-query for each child. 
 If a query contains the whole subarray of a node, we 
 can use the precomputed value at the node. Using this 

--- a/src/data-structures/tree/segment-tree/SegmentTree.js
+++ b/src/data-structures/tree/segment-tree/SegmentTree.js
@@ -25,6 +25,11 @@ export default class SegmentTree {
     let segmentTreeArrayLength;
     const inputArrayLength = inputArray.length;
 
+    // An empty input array is represented by an empty segment tree.
+    if (inputArrayLength === 0) {
+      return [];
+    }
+
     if (isPowerOfTwo(inputArrayLength)) {
       // If original array length is a power of two.
       segmentTreeArrayLength = (2 * inputArrayLength) - 1;
@@ -46,6 +51,11 @@ export default class SegmentTree {
    * Build segment tree.
    */
   buildSegmentTree() {
+    // There is nothing to build for an empty input array.
+    if (this.inputArray.length === 0) {
+      return;
+    }
+
     const leftIndex = 0;
     const rightIndex = this.inputArray.length - 1;
     const position = 0;

--- a/src/data-structures/tree/segment-tree/__test__/SegmentTree.test.js
+++ b/src/data-structures/tree/segment-tree/__test__/SegmentTree.test.js
@@ -98,4 +98,10 @@ describe('SegmentTree', () => {
     expect(segmentTree.rangeQuery(4, 5)).toBe(3);
     expect(segmentTree.rangeQuery(3, 3)).toBe(0);
   });
+
+  it('should build an empty tree for an empty input array', () => {
+    const segmentTree = new SegmentTree([], Math.min, Infinity);
+
+    expect(segmentTree.segmentTree).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

A systematic audit of the repository (every claimed bug was verified by executing a concrete failing input before fixing) uncovered a number of correctness bugs, wrong documentation claims, and a few gaps. This PR fixes them, adds 54 regression tests, and keeps the full suite green: **179 suites / 641 tests pass, ESLint clean**.

## Data structure fixes

- **AVL tree** — four defects: `rotateLeftLeft`/`rotateRightRight` always attached the rotated-up node to a fixed side of the parent, losing whole subtrees when the unbalanced node sat on the other side (repro: insert `50, 30, 70, 65, 60` → node 30 vanished); all rotations corrupted parent pointers by attaching a transferred child before detaching it (`setLeft`/`setRight` detach logic then nulled the fresh parent reference); `balance()` ignored the zero-balance-factor child case that removals produce; and `remove()` only balanced the root once instead of retracing from the deepest affected node. A 200-operation randomized insert/remove invariant test now guards all of this.
- **BinaryTreeNode.replaceChild** never updated the promoted child's parent pointer, breaking parent chains after every one-child BST removal.
- **BST remove** unconditionally nulled the parent pointer of nodes that stayed in the tree (two-children case) and erased an empty root with `undefined` while `insert` checks for `null`, so a re-used tree grew a phantom root.
- **Heap.remove** used `!parentItem` to mean "no parent", so parent *values* of `0`/`''`/`false` heapified in the wrong direction — PriorityQueue (default priority 0) was the common victim.
- **LinkedList.insert** at index == length linked the node after the tail without updating `tail`; the next `append` silently dropped it.
- **RedBlackTree** repainted the existing node red when inserting a duplicate value, breaking the red-red invariant.
- **MinHeapAdhoc/MaxHeapAdhoc** crashed on any non-empty constructor array (`heap.forEach(this.add)` loses `this`).
- **LRUCache / HashTable** misbehaved with keys inherited from `Object.prototype` (`'constructor'`, `'__proto__'`) — both registries now use prototype-less objects.
- **SegmentTree** crashed on an empty input array (`log2(0)` → array length −1).

## Graph algorithm fixes

- `articulationPoints`, `graphBridges`, `detectUndirectedCycle` only examined the first connected component.
- `eulerianPath` crashed on valid inputs (bridge detection ran from a vertex Fleury had already isolated) and on disconnected even-degree graphs; it now validates connectivity and rejects directed graphs explicitly.
- `bfTravellingSalesman` never counted the closing edge's weight and accepted "tours" that skipped vertices.
- `floydWarshall` mixed two conventions in `nextVertices` (start vertex for direct edges, middle vertex on relaxation), making path reconstruction impossible; now uses the standard successor convention, with a path-reconstruction test.
- `bellmanFord` silently returned finite distances for graphs with negative cycles; it now throws after the standard extra relaxation pass.
- `Graph.addEdge` re-attached edge objects already present in a vertex's edge list, so building an MST via Kruskal/Prim corrupted the *input* graph's vertex degrees.
- Default BFS/DFS `allowTraversal` never marked the start vertex seen, so a directed cycle re-entered it (`A→B→C→A` visited A twice).
- `stronglyConnectedComponents` left the caller's graph permanently reversed; `prim` now throws on disconnected graphs instead of silently returning a partial tree.

## Math / ML fixes

- Inverse FFT applied numeric `/=` to `ComplexNumber` objects → `NaN` for every signal; the test helper was NaN-blind (`Math.abs(NaN) > delta` is `false`) and is fixed too. Forward/inverse FFT kernels were also swapped relative to the standard convention and to `discreteFourierTransform.js` in the same folder.
- `kMeans` produced `NaN` centroids for empty clusters and returned cluster `-1` for every point; `euclideanDistance` rounded to 2 decimals (`toFixed(2)`), destroying kNN tie-breaking.
- Infinite loops fixed: `bitLength(2**30)` (31-bit `<<` wrap), `fibonacciNth(0)` / `fibonacci(0)`, `squareRoot(2, 17)` (Newton's iteration 2-cycles between adjacent doubles), and `fastPowering` with negative exponents — which are now supported (`2^-3 → 0.125`).
- `bitsToFloat` now decodes IEEE 754 zeros, subnormals, and ±Infinity/NaN (previously the all-zero bit pattern decoded to 2⁻¹⁵, i.e. zero was unrepresentable).
- `isPowerOfTwo(0)` returned `true`; `classicPolynome` mutated the caller's coefficients array; `weightedRandom` could return a zero-weight item when `Math.random()` hit exactly 0.

## Sorting / search / sets / string / crypto fixes

- `interpolationSearch` hung forever when the seek value was above the array maximum or between elements of non-uniform data.
- 0/1 knapsack traceback was broken (single item `{v:5, w:2}`, limit 3 → empty selection, value 0); unbounded knapsack pushed items with zero possible quantity, exceeding the weight limit.
- `RadixSort` placed shorter strings after `'z'` instead of before `'a'` (`['b','ba']` → `['ba','b']`) and mangled negative integers (now handled); `BucketSort` delegated buckets to RadixSort, which does zero passes on floats — buckets are now comparison-sorted.
- `rabinKarp`/`PolynomialHash.roll` indexed by UTF-16 code units against a code-point-based `hash()`, so any astral symbol in the window corrupted every subsequent rolling hash; the long-standing commented-out `@TODO: Provide Unicode support` test is now enabled and passing.
- `zAlgorithm` lost matches when the text contained the internal `'$'` separator (`zAlgorithm('a$a', 'a')` → `[2]` instead of `[0, 2]`).
- `railFenceCipher` dropped characters on encode and threw on decode with a single rail; `hillCipher` encrypted lowercase input inconsistently with uppercase (`'act'` ≠ `'ACT'`).
- `hanoiTower(0)` and both permutation generators recursed infinitely on empty input; `dpTopDownJumpGame` copied its memo table on every call (and wrote the seed to index −1), so the claimed memoization never happened; `validParentheses('')` returned `false`, contradicting the README's own vacuous-truth definition.

## Documentation corrections (English READMEs)

Wrong Big-O claims (segment tree build is O(n), BST table now notes the unbalanced worst case, Z-algorithm space is O(|W|+|T|), recursive-staircase brute force is O(n) space), wrong math (polynomial-hash formula exponents, complex-number conjugate identity, square-matrix-rotation described a reflection order that yields a **counterclockwise** rotation), inverted pseudocode conditions (tree BFS, BST findMin/findMax preconditions), an inverted k-means stopping condition, and a few dozen grammar/typo fixes.

## Additions

- **Extended Euclidean algorithm** (`extendedEuclideanAlgorithm.js`) with Bézout coefficients — the euclidean-algorithm README already discussed the identity with nothing computing it.
- Deque row in the main README complexity table; missing DP section in the best-time-to-buy-sell-stocks README.
- Honest notes where implementations differ from cheat-sheet values (this repo's heap sort uses O(n) memory; `DisjointSet.js` union is linear vs. the inverse-Ackermann `DisjointSetAdhoc.js`).

## Notes for reviewers

- Two existing tests encoded buggy behavior and were deliberately updated: `floydWarshall.test.js` (asserted the inconsistent `nextVertices` values) and `validParentheses.test.js` (asserted `isValid('') === false`).
- Two design limitations were documented rather than redesigned: PriorityQueue keys priorities by item value (duplicates share one priority), and Kruskal/Prim MSTs share vertex objects with the source graph (the degree-corruption side effect is fixed here; full isolation would change the API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)