### PR TITLE
docs: fix typos in valid parentheses README

### DIFF
--- a/src/algorithms/stack/valid-parentheses/README.md
+++ b/src/algorithms/stack/valid-parentheses/README.md
@@ -33,10 +33,10 @@ This is actually a very common interview question and a very good example of how
 The problem can be solved in two ways
 
 ### Bruteforce Approach
-We can iterate through the string and then for each character in the string, we check for it's last closing character in the the string. Once we find the last closing character in the string, we remove both characters and then repeat the iteration, if we don't find a closing character for an opening character, then the string is invalid. The time complexity of this would be O(n^2) which is not so efficient.
+We can iterate through the string and then for each character in the string, we check for its last closing character in the string. Once we find the last closing character in the string, we remove both characters and then repeat the iteration, if we don't find a closing character for an opening character, then the string is invalid. The time complexity of this would be O(n^2) which is not so efficient.
 
 ### Using a Stack
-We can use a hashtable to store all opening characters and the value would be the respective closing character. We can then iterate through the string and if we encounter an opening parantheses, we push it's closing character to the stack. If we ecounter a closing paraentheses, then we pop the stack and confirm that the popped element is equal to the current closing parentheses character. If it is not then the string is invalid. At the end of the iteration, we also need to check that the stack is empty. If it is not then the string is invalid. If it is, then the string is valid. This is a more efficient approach with a Time complexity and Space complexity of O(n).
+We can use a hashtable to store all opening characters and the value would be the respective closing character. We can then iterate through the string and if we encounter an opening parenthesis, we push its closing character to the stack. If we encounter a closing parenthesis, then we pop the stack and confirm that the popped element is equal to the current closing parentheses character. If it is not then the string is invalid. At the end of the iteration, we also need to check that the stack is empty. If it is not then the string is invalid. If it is, then the string is valid. This is a more efficient approach with a Time complexity and Space complexity of O(n).
 
 
 ## References


### PR DESCRIPTION
## Summary
- Fix a duplicated word and a few spelling/grammar typos in the valid parentheses README explanation.
- Keep the change limited to documentation wording; no algorithm behavior is changed.

## Why
The README currently contains small typos such as "in the the string", "parantheses", "ecounter", and "paraentheses" in the solution explanation. Correcting them makes the educational text easier to read.

## Verification
- Ran `git diff --check` successfully.
- Reviewed the final diff; it changes only two documentation lines.