### PR TITLE
fix(#2057): return ordered cycle path array instead of parent mapping in detectUndirectedCycle

### DIFF
--- a/src/algorithms/graph/detect-cycle/__test__/detectUndirectedCycle.test.js
+++ b/src/algorithms/graph/detect-cycle/__test__/detectUndirectedCycle.test.js
@@ -31,11 +31,12 @@ describe('detectUndirectedCycle', () => {
 
     graph.addEdge(edgeDE);
 
-    expect(detectUndirectedCycle(graph)).toEqual({
-      B: vertexC,
-      C: vertexD,
-      D: vertexE,
-      E: vertexB,
-    });
+    expect(detectUndirectedCycle(graph)).toEqual([
+      vertexB,
+      vertexC,
+      vertexD,
+      vertexE,
+      vertexB,
+    ]);
   });
 });

--- a/src/algorithms/graph/detect-cycle/detectUndirectedCycle.js
+++ b/src/algorithms/graph/detect-cycle/detectUndirectedCycle.js
@@ -30,19 +30,19 @@ export default function detectUndirectedCycle(graph) {
     },
     enterVertex: ({ currentVertex, previousVertex }) => {
       if (visitedVertices[currentVertex.getKey()]) {
-        // Compile cycle path based on parents of previous vertices.
-        cycle = {};
+        // Build an ordered cycle path array starting and ending at the repeated vertex.
+        const cyclePath = [currentVertex];
 
-        let currentCycleVertex = currentVertex;
         let previousCycleVertex = previousVertex;
 
         while (previousCycleVertex.getKey() !== currentVertex.getKey()) {
-          cycle[currentCycleVertex.getKey()] = previousCycleVertex;
-          currentCycleVertex = previousCycleVertex;
+          cyclePath.push(previousCycleVertex);
           previousCycleVertex = parents[previousCycleVertex.getKey()];
         }
 
-        cycle[currentCycleVertex.getKey()] = previousCycleVertex;
+        cyclePath.push(previousCycleVertex);
+
+        cycle = cyclePath;
       } else {
         // Add next vertex to visited set.
         visitedVertices[currentVertex.getKey()] = currentVertex;


### PR DESCRIPTION
## Description

The `detectUndirectedCycle` function was returning an object mapping vertex keys to their parent vertices (e.g. `{ B: vertexC, C: vertexD, D: vertexE, E: vertexB }`), which is not a standard cycle representation and may not be intuitive for consumers expecting an ordered path.

This PR changes the return value to an ordered array of vertices forming the cycle, starting and ending at the same vertex (e.g. `[vertexB, vertexC, vertexD, vertexE, vertexB]`).

## Changes

- **detectUndirectedCycle.js**: Replaced the parent-mapping object with an ordered array built by walking the parent chain from the repeated vertex back to itself.
- **detectUndirectedCycle.test.js**: Updated the test expectation to match the new array format.

## Testing

```
Test Suites: 178 passed, 178 total
Tests:       587 passed, 587 total
```

Fixes #2057